### PR TITLE
Release: 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .env.prod
 node_modules/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env.prod
 node_modules/
 .idea/
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "cross-env": "^7.0.3",
     "eslint": "^7.22.0",
     "prettier": "^2.2.1",
-    "prisma": "^2.19.0",
+    "prisma": "^2.29.1",
     "ts-node-dev": "^1.1.6",
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@prisma/client": "^2.19.0",
+    "@prisma/client": "^2.29.1",
     "@sentry/browser": "^6.11.0",
     "@sentry/node": "^6.11.0",
     "@sentry/tracing": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/express": "^4.17.13",
     "@types/spotify-web-api-node": "^5.0.2",
     "datadog-metrics": "^0.9.3",
+    "dayjs": "^1.10.7",
     "discord-reply": "^0.1.2",
     "discord.js": "^13.1.0-dev.1628683680.75b48d8",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tunes.ninja",
-  "version": "1.0.0",
+  "version": "2.0.0-infdev",
   "main": "dist/index.js",
   "repository": "https://github.com/jacc/tunes.ninja.git",
   "author": "Jack LaFond <jack.lafond@icloud.com>",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "dependencies": {
     "@prisma/client": "^2.19.0",
+    "@sentry/browser": "^6.11.0",
+    "@sentry/node": "^6.11.0",
+    "@sentry/tracing": "^6.11.0",
     "@types/datadog-metrics": "^0.6.2",
     "@types/express": "^4.17.13",
     "@types/spotify-web-api-node": "^5.0.2",

--- a/prisma/migrations/20210822232859_new_playlist/migration.sql
+++ b/prisma/migrations/20210822232859_new_playlist/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `platform` to the `JoshChannel` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `playlistID` to the `JoshChannel` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "JoshChannel" ADD COLUMN     "platform" TEXT NOT NULL,
+ADD COLUMN     "playlistID" TEXT NOT NULL;

--- a/prisma/migrations/20210823011531_remove_premium/migration.sql
+++ b/prisma/migrations/20210823011531_remove_premium/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `premium` on the `JoshChannel` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "JoshChannel" DROP COLUMN "premium";

--- a/prisma/migrations/20210823055742_/migration.sql
+++ b/prisma/migrations/20210823055742_/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The primary key for the `JoshChannel` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- AlterTable
+ALTER TABLE "JoshChannel" DROP CONSTRAINT "JoshChannel_pkey",
+ADD PRIMARY KEY ("playlistID");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,5 +28,6 @@ model User {
 
 model JoshChannel {
   id      String  @id
-  premium Boolean
+  platform String
+  playlistID String
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,7 @@ model User {
 }
 
 model JoshChannel {
-  id      String  @id
+  id      String
   platform String
-  playlistID String
+  playlistID String @id
 }

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -31,13 +31,14 @@ export const playlists: MessageCommand = {
 
     let url;
     if (
-      interaction.options.get("message")!.message!.author.id ===
-        "840585628408217610" &&
-      interaction.options.get("message")!.message!.components
+        interaction.options.get("message")!.message!.author.id ===
+        interaction.client.user!.id &&
+        interaction.options.get("message")!.message!.components
     ) {
       const button =
         interaction.options.get("message")!.message!.components![0]
           .components[0];
+      console.log(button)
       if (button.type !== "BUTTON") return; // Do something, not a button
       if (button.style !== "LINK") return; // Do something, not a link button
       url = linkSchema.safeParse(button.url);

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -38,7 +38,6 @@ export const playlists: MessageCommand = {
       const button =
         interaction.options.get("message")!.message!.components![0]
           .components[0];
-      console.log(button)
       if (button.type !== "BUTTON") return; // Do something, not a button
       if (button.style !== "LINK") return; // Do something, not a link button
       url = linkSchema.safeParse(button.url);

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -15,7 +15,7 @@ const linkSchema = z.string().refine((x) => {
 }, "");
 
 export const playlists: MessageCommand = {
-  name: "Add to Spotify Playlist",
+  name: "Add to Playlist",
   inhibitors: [voted],
   type: "MESSAGE",
   async run(interaction) {
@@ -32,28 +32,48 @@ export const playlists: MessageCommand = {
     }
 
     const song = await SongsApi.getLinks(url.data);
-    const playlists = await JoshAPI.getPlaylists(interaction.user.id);
 
-    const row = new MessageActionRow().addComponents(
-      new MessageSelectMenu()
-        .setCustomId(`select_${interaction.user.id}`)
-        .setPlaceholder("Select a playlist from the list")
-        .addOptions(
-          playlists.playlists.map(
-            (p: { playlist_display_name: string; playlist_id: string }) => {
-              return {
-                label: p.playlist_display_name,
-                value: `_${p.playlist_id}_${
-                  song.links!.spotify!.split(
-                    "https://open.spotify.com/track/"
-                  )[1]
-                }`,
-                emoji: "<:spotify:847868739298131998>",
-              };
-            }
-          )
-        )
-    );
+    const user = await JoshAPI.user(interaction.user.id)
+
+    console.log(user)
+
+    // if (!user.services.appleMusic && !user.services.spotify) {
+    //   throw new Error("You don't have any music services linked! Do `/api link` to get started!")
+    // }
+
+    const rows = []
+
+    for (const platform in user.services) {
+      if (!user.services[platform]) {
+        const playlists = await JoshAPI.getPlaylists(interaction.user.id, platform);
+
+        console.log(playlists)
+
+        // const row = new MessageActionRow().addComponents(
+        //   new MessageSelectMenu()
+        //     .setCustomId(`select_${interaction.user.id}`)
+        //     .setPlaceholder("Select a playlist from the list")
+        //     .addOptions(
+        //       playlists.playlists.map(
+        //         (p: { playlist_display_name: string; playlist_id: string }) => {
+        //           return {
+        //             label: p.playlist_display_name,
+        //             value: `_${p.playlist_id}_${
+        //               song.links!.spotify!.split(
+        //                 "https://open.spotify.com/track/"
+        //               )[1]
+        //             }`,
+        //             emoji: "<:spotify:847868739298131998>",
+        //           };
+        //         }
+        //       )
+        //     )
+        // );
+        //
+        // rows.push(row)
+      }
+    }
+
 
     const embed = new MessageEmbed()
       .setAuthor(
@@ -68,7 +88,7 @@ export const playlists: MessageCommand = {
 
     await interaction.editReply({
       embeds: [embed],
-      components: [row],
+      // components: rows,
     });
   },
 };

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -1,6 +1,12 @@
 import { MessageCommand } from "../../types/command";
 import { JoshAPI } from "../../services/api/josh";
-import { MessageActionRow, MessageEmbed, MessageSelectMenu } from "discord.js";
+import {
+  Constants,
+  MessageActionRow,
+  MessageButton,
+  MessageEmbed,
+  MessageSelectMenu,
+} from "discord.js";
 import { SongsApi } from "../../services/api/song";
 import * as z from "zod";
 import { voted } from "../../inhibitors/voted";
@@ -23,9 +29,23 @@ export const playlists: MessageCommand = {
   async run(interaction) {
     await interaction.deferReply({ ephemeral: true });
 
-    const url = linkSchema.safeParse(
-      interaction.options.get("message")!.message!.content
-    );
+    let url;
+    if (
+      interaction.options.get("message")!.message!.author.id ===
+        "840585628408217610" &&
+      interaction.options.get("message")!.message!.components
+    ) {
+      const button =
+        interaction.options.get("message")!.message!.components![0]
+          .components[0];
+      if (button.type !== "BUTTON") return; // Do something, not a button
+      if (button.style !== "LINK") return; // Do something, not a link button
+      url = linkSchema.safeParse(button.url);
+    } else {
+      url = linkSchema.safeParse(
+        interaction.options.get("message")!.message!.content
+      );
+    }
 
     if (!url.success) {
       throw new Error(

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -1,102 +1,109 @@
-import {MessageCommand} from "../../types/command";
-import {JoshAPI} from "../../services/api/josh";
-import {MessageActionRow, MessageEmbed, MessageSelectMenu} from "discord.js";
-import {SongsApi} from "../../services/api/song";
+import { MessageCommand } from "../../types/command";
+import { JoshAPI } from "../../services/api/josh";
+import { MessageActionRow, MessageEmbed, MessageSelectMenu } from "discord.js";
+import { SongsApi } from "../../services/api/song";
 import * as z from "zod";
-import {voted} from "../../inhibitors/voted";
-import {platforms} from "../../services/events/interaction";
-import {PLATFORM_EMOJI} from "../../services/reply-song";
+import { voted } from "../../inhibitors/voted";
+import { platforms } from "../../services/events/interaction";
+import { PLATFORM_EMOJI } from "../../services/reply-song";
 
 const linkSchema = z.string().refine((x) => {
-    return (
-        x.includes("open.spotify.com/track") ||
-        x.includes("open.spotify.com/album") ||
-        x.includes("music.apple.com") ||
-        x.includes("soundcloud.com")
-    );
+  return (
+    x.includes("open.spotify.com/track") ||
+    x.includes("open.spotify.com/album") ||
+    x.includes("music.apple.com") ||
+    x.includes("soundcloud.com")
+  );
 }, "");
 
 export const playlists: MessageCommand = {
-    name: "Add to Playlist",
-    inhibitors: [voted],
-    type: "MESSAGE",
-    async run(interaction) {
-        await interaction.deferReply({ephemeral: true});
+  name: "Add to Playlist",
+  inhibitors: [voted],
+  type: "MESSAGE",
+  async run(interaction) {
+    await interaction.deferReply({ ephemeral: true });
 
-        const url = linkSchema.safeParse(
-            interaction.options.get("message")!.message!.content
+    const url = linkSchema.safeParse(
+      interaction.options.get("message")!.message!.content
+    );
+
+    if (!url.success) {
+      throw new Error(
+        "I couldn't find a valid song link in this message - check and try again."
+      );
+    }
+
+    const song = await SongsApi.getLinks(url.data);
+
+    const user = await JoshAPI.getUser(interaction.user.id);
+
+    if (!user.services.appleMusic && !user.services.spotify) {
+      throw new Error(
+        "You don't have any music services linked! Do `/api link` to get started!"
+      );
+    }
+
+    const rows = [];
+
+    for (const platform in user.services) {
+      if (user.services[platform]) {
+        const playlists = await JoshAPI.getUserPlaylists(
+          interaction.user.id,
+          platforms[platform]
         );
 
-        if (!url.success) {
-            throw new Error(
-                "I couldn't find a valid song link in this message - check and try again."
-            );
+        let songID: string;
+
+        switch (platform) {
+          case "spotify":
+            songID = song.links!.spotify!.split(
+              "https://open.spotify.com/track/"
+            )[1];
+            break;
+          case "appleMusic":
+            songID = song.links!.apple_music!.split("?i=")[1];
         }
 
-        const song = await SongsApi.getLinks(url.data);
-
-        const user = await JoshAPI.user(interaction.user.id)
-
-        if (!user.services.appleMusic && !user.services.spotify) {
-            throw new Error("You don't have any music services linked! Do `/api link` to get started!")
-        }
-
-        const rows = []
-
-        for (const platform in user.services) {
-            if (user.services[platform]) {
-                const playlists = await JoshAPI.getPlaylists(interaction.user.id, platforms[platform]
-                );
-
-                let songID: string;
-
-                switch (platform) {
-                    case "spotify":
-                        songID = song.links!.spotify!.split("https://open.spotify.com/track/")[1]
-                        break
-                    case "appleMusic":
-                        songID = song.links!.apple_music!.split("?i=")[1]
+        const row = new MessageActionRow().addComponents(
+          new MessageSelectMenu()
+            .setCustomId(`select_${interaction.user.id}_${platform}`)
+            .setPlaceholder(
+              `Select a ${platforms[platform]
+                .split("-")
+                .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+                .join(" ")} playlist from the list`
+            )
+            .addOptions(
+              playlists.playlists.map(
+                (p: { playlist_display_name: string; playlist_id: string }) => {
+                  return {
+                    label: p.playlist_display_name,
+                    value: `_${p.playlist_id}_${songID}`,
+                    emoji: PLATFORM_EMOJI[platform],
+                  };
                 }
-
-                const row = new MessageActionRow().addComponents(
-                    new MessageSelectMenu()
-                        .setCustomId(`select_${interaction.user.id}_${platform}`)
-                        .setPlaceholder(`Select a ${platforms[platform]
-                        .split("-")
-                        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
-                        .join(" ")} playlist from the list`)
-                        .addOptions(
-                            playlists.playlists.map(
-                                (p: { playlist_display_name: string; playlist_id: string }) => {
-                                    return {
-                                        label: p.playlist_display_name,
-                                        value: `_${p.playlist_id}_${songID}`,
-                                        emoji: PLATFORM_EMOJI[platform]
-                                    };
-                                }
-                            )
-                        )
-                );
-
-                rows.push(row)
-            }
-        }
-
-
-        const embed = new MessageEmbed()
-            .setAuthor(
-                `${song.title} by ${song.artist}`,
-                song.thumbnail ? song.thumbnail : ""
+              )
             )
-            .setColor(0x212121)
-            .setDescription(
-                "Add this song to your playlist by selecting one in the dropdown."
-            )
-            .setFooter("Playlist not showing? Discord only has 25 select options");
+        );
 
-        await interaction.editReply({
-            embeds: [embed],
-            components: rows,
-        });
-    },
+        rows.push(row);
+      }
+    }
+
+    const embed = new MessageEmbed()
+      .setAuthor(
+        `${song.title} by ${song.artist}`,
+        song.thumbnail ? song.thumbnail : ""
+      )
+      .setColor(0x212121)
+      .setDescription(
+        "Add this song to your playlist by selecting one in the dropdown."
+      )
+      .setFooter("Playlist not showing? Discord only has 25 select options");
+
+    await interaction.editReply({
+      embeds: [embed],
+      components: rows,
+    });
+  },
 };

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -1,102 +1,102 @@
-import { MessageCommand } from "../../types/command";
-import { JoshAPI } from "../../services/api/josh";
-import { MessageActionRow, MessageEmbed, MessageSelectMenu } from "discord.js";
-import { SongsApi } from "../../services/api/song";
+import {MessageCommand} from "../../types/command";
+import {JoshAPI} from "../../services/api/josh";
+import {MessageActionRow, MessageEmbed, MessageSelectMenu} from "discord.js";
+import {SongsApi} from "../../services/api/song";
 import * as z from "zod";
-import { voted } from "../../inhibitors/voted";
+import {voted} from "../../inhibitors/voted";
 import {platforms} from "../../services/events/interaction";
 import {PLATFORM_EMOJI} from "../../services/reply-song";
 
 const linkSchema = z.string().refine((x) => {
-  return (
-    x.includes("open.spotify.com/track") ||
-    x.includes("open.spotify.com/album") ||
-    x.includes("music.apple.com") ||
-    x.includes("soundcloud.com")
-  );
+    return (
+        x.includes("open.spotify.com/track") ||
+        x.includes("open.spotify.com/album") ||
+        x.includes("music.apple.com") ||
+        x.includes("soundcloud.com")
+    );
 }, "");
 
 export const playlists: MessageCommand = {
-  name: "Add to Playlist",
-  inhibitors: [voted],
-  type: "MESSAGE",
-  async run(interaction) {
-    await interaction.deferReply({ ephemeral: true });
+    name: "Add to Playlist",
+    inhibitors: [voted],
+    type: "MESSAGE",
+    async run(interaction) {
+        await interaction.deferReply({ephemeral: true});
 
-    const url = linkSchema.safeParse(
-      interaction.options.get("message")!.message!.content
-    );
-
-    if (!url.success) {
-      throw new Error(
-        "I couldn't find a valid song link in this message - check and try again."
-      );
-    }
-
-    const song = await SongsApi.getLinks(url.data);
-
-    const user = await JoshAPI.user(interaction.user.id)
-
-    if (!user.services.appleMusic && !user.services.spotify) {
-      throw new Error("You don't have any music services linked! Do `/api link` to get started!")
-    }
-
-    const rows = []
-
-    for (const platform in user.services) {
-      if (user.services[platform]) {
-        const playlists = await JoshAPI.getPlaylists(interaction.user.id, platforms[platform]
+        const url = linkSchema.safeParse(
+            interaction.options.get("message")!.message!.content
         );
 
-        let songID: string;
-
-        switch (platform) {
-          case "spotify":
-            songID = song.links!.spotify!.split("https://open.spotify.com/track/")[1]
-            break
-          case "appleMusic":
-            songID = song.links!.apple_music!.split("?i=")[1]
+        if (!url.success) {
+            throw new Error(
+                "I couldn't find a valid song link in this message - check and try again."
+            );
         }
 
-        const row = new MessageActionRow().addComponents(
-          new MessageSelectMenu()
-            .setCustomId(`select_${interaction.user.id}_${platform}`)
-            .setPlaceholder(`Select a ${platforms[platform]
-        .split("-")
-        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
-        .join(" ")} playlist from the list`)
-            .addOptions(
-              playlists.playlists.map(
-                (p: { playlist_display_name: string; playlist_id: string }) => {
-                  return {
-                    label: p.playlist_display_name,
-                    value: `_${p.playlist_id}_${songID}`,
-                    emoji: PLATFORM_EMOJI[platform]
-                  };
+        const song = await SongsApi.getLinks(url.data);
+
+        const user = await JoshAPI.user(interaction.user.id)
+
+        if (!user.services.appleMusic && !user.services.spotify) {
+            throw new Error("You don't have any music services linked! Do `/api link` to get started!")
+        }
+
+        const rows = []
+
+        for (const platform in user.services) {
+            if (user.services[platform]) {
+                const playlists = await JoshAPI.getPlaylists(interaction.user.id, platforms[platform]
+                );
+
+                let songID: string;
+
+                switch (platform) {
+                    case "spotify":
+                        songID = song.links!.spotify!.split("https://open.spotify.com/track/")[1]
+                        break
+                    case "appleMusic":
+                        songID = song.links!.apple_music!.split("?i=")[1]
                 }
-              )
+
+                const row = new MessageActionRow().addComponents(
+                    new MessageSelectMenu()
+                        .setCustomId(`select_${interaction.user.id}_${platform}`)
+                        .setPlaceholder(`Select a ${platforms[platform]
+                        .split("-")
+                        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+                        .join(" ")} playlist from the list`)
+                        .addOptions(
+                            playlists.playlists.map(
+                                (p: { playlist_display_name: string; playlist_id: string }) => {
+                                    return {
+                                        label: p.playlist_display_name,
+                                        value: `_${p.playlist_id}_${songID}`,
+                                        emoji: PLATFORM_EMOJI[platform]
+                                    };
+                                }
+                            )
+                        )
+                );
+
+                rows.push(row)
+            }
+        }
+
+
+        const embed = new MessageEmbed()
+            .setAuthor(
+                `${song.title} by ${song.artist}`,
+                song.thumbnail ? song.thumbnail : ""
             )
-        );
+            .setColor(0x212121)
+            .setDescription(
+                "Add this song to your playlist by selecting one in the dropdown."
+            )
+            .setFooter("Playlist not showing? Discord only has 25 select options");
 
-        rows.push(row)
-      }
-    }
-
-
-    const embed = new MessageEmbed()
-      .setAuthor(
-        `${song.title} by ${song.artist}`,
-        song.thumbnail ? song.thumbnail : ""
-      )
-      .setColor(0x212121)
-      .setDescription(
-        "Add this song to your playlist by selecting one in the dropdown."
-      )
-      .setFooter("Playlist not showing? Discord only has 25 select options");
-
-    await interaction.editReply({
-      embeds: [embed],
-      components: rows,
-    });
-  },
+        await interaction.editReply({
+            embeds: [embed],
+            components: rows,
+        });
+    },
 };

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -61,7 +61,7 @@ export const playlists: MessageCommand = {
             )[1];
             break;
           case "appleMusic":
-            songID = song.links!.apple_music!.split("?i=")[1];
+            songID = song.links!.apple_music!.split("i=")[1].split("&")[0];
         }
 
         const row = new MessageActionRow().addComponents(

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -64,6 +64,8 @@ export const playlists: MessageCommand = {
             songID = song.links!.apple_music!.split("i=")[1].split("&")[0];
         }
 
+        console.log(playlists.playlists);
+
         const row = new MessageActionRow().addComponents(
           new MessageSelectMenu()
             .setCustomId(`select_${interaction.user.id}_${platform}`)

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -35,11 +35,7 @@ export const playlists: MessageCommand = {
 
     const song = await SongsApi.getLinks(url.data);
 
-    console.log(song)
-
     const user = await JoshAPI.user(interaction.user.id)
-
-    console.log(user)
 
     if (!user.services.appleMusic && !user.services.spotify) {
       throw new Error("You don't have any music services linked! Do `/api link` to get started!")
@@ -49,11 +45,8 @@ export const playlists: MessageCommand = {
 
     for (const platform in user.services) {
       if (user.services[platform]) {
-        console.log(platforms[platform])
         const playlists = await JoshAPI.getPlaylists(interaction.user.id, platforms[platform]
         );
-
-        console.log(platform)
 
         let songID: string;
 
@@ -62,13 +55,16 @@ export const playlists: MessageCommand = {
             songID = song.links!.spotify!.split("https://open.spotify.com/track/")[1]
             break
           case "appleMusic":
-            songID = song.links!.apple_music!.split("?")[0]
+            songID = song.links!.apple_music!.split("?i=")[1]
         }
 
         const row = new MessageActionRow().addComponents(
           new MessageSelectMenu()
-            .setCustomId(`select_${interaction.user.id}`)
-            .setPlaceholder("Select a playlist from the list")
+            .setCustomId(`select_${interaction.user.id}_${platform}`)
+            .setPlaceholder(`Select a ${platforms[platform]
+        .split("-")
+        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+        .join(" ")} playlist from the list`)
             .addOptions(
               playlists.playlists.map(
                 (p: { playlist_display_name: string; playlist_id: string }) => {

--- a/src/commands/context/add.ts
+++ b/src/commands/context/add.ts
@@ -4,6 +4,8 @@ import { MessageActionRow, MessageEmbed, MessageSelectMenu } from "discord.js";
 import { SongsApi } from "../../services/api/song";
 import * as z from "zod";
 import { voted } from "../../inhibitors/voted";
+import {platforms} from "../../services/events/interaction";
+import {PLATFORM_EMOJI} from "../../services/reply-song";
 
 const linkSchema = z.string().refine((x) => {
   return (
@@ -33,44 +35,54 @@ export const playlists: MessageCommand = {
 
     const song = await SongsApi.getLinks(url.data);
 
+    console.log(song)
+
     const user = await JoshAPI.user(interaction.user.id)
 
     console.log(user)
 
-    // if (!user.services.appleMusic && !user.services.spotify) {
-    //   throw new Error("You don't have any music services linked! Do `/api link` to get started!")
-    // }
+    if (!user.services.appleMusic && !user.services.spotify) {
+      throw new Error("You don't have any music services linked! Do `/api link` to get started!")
+    }
 
     const rows = []
 
     for (const platform in user.services) {
-      if (!user.services[platform]) {
-        const playlists = await JoshAPI.getPlaylists(interaction.user.id, platform);
+      if (user.services[platform]) {
+        console.log(platforms[platform])
+        const playlists = await JoshAPI.getPlaylists(interaction.user.id, platforms[platform]
+        );
 
-        console.log(playlists)
+        console.log(platform)
 
-        // const row = new MessageActionRow().addComponents(
-        //   new MessageSelectMenu()
-        //     .setCustomId(`select_${interaction.user.id}`)
-        //     .setPlaceholder("Select a playlist from the list")
-        //     .addOptions(
-        //       playlists.playlists.map(
-        //         (p: { playlist_display_name: string; playlist_id: string }) => {
-        //           return {
-        //             label: p.playlist_display_name,
-        //             value: `_${p.playlist_id}_${
-        //               song.links!.spotify!.split(
-        //                 "https://open.spotify.com/track/"
-        //               )[1]
-        //             }`,
-        //             emoji: "<:spotify:847868739298131998>",
-        //           };
-        //         }
-        //       )
-        //     )
-        // );
-        //
-        // rows.push(row)
+        let songID: string;
+
+        switch (platform) {
+          case "spotify":
+            songID = song.links!.spotify!.split("https://open.spotify.com/track/")[1]
+            break
+          case "appleMusic":
+            songID = song.links!.apple_music!.split("?")[0]
+        }
+
+        const row = new MessageActionRow().addComponents(
+          new MessageSelectMenu()
+            .setCustomId(`select_${interaction.user.id}`)
+            .setPlaceholder("Select a playlist from the list")
+            .addOptions(
+              playlists.playlists.map(
+                (p: { playlist_display_name: string; playlist_id: string }) => {
+                  return {
+                    label: p.playlist_display_name,
+                    value: `_${p.playlist_id}_${songID}`,
+                    emoji: PLATFORM_EMOJI[platform]
+                  };
+                }
+              )
+            )
+        );
+
+        rows.push(row)
       }
     }
 
@@ -88,7 +100,7 @@ export const playlists: MessageCommand = {
 
     await interaction.editReply({
       embeds: [embed],
-      // components: rows,
+      components: rows,
     });
   },
 };

--- a/src/commands/context/play.ts
+++ b/src/commands/context/play.ts
@@ -20,9 +20,24 @@ export const playOnSpotify: MessageCommand = {
   type: "MESSAGE",
   async run(interaction) {
     await interaction.deferReply({ ephemeral: true });
-    const url = linkSchema.safeParse(
-      interaction.options.get("message")!.message!.content
-    );
+
+    let url;
+    if (
+      interaction.options.get("message")!.message!.author.id ===
+        "840585628408217610" &&
+      interaction.options.get("message")!.message!.components
+    ) {
+      const button =
+        interaction.options.get("message")!.message!.components![0]
+          .components[0];
+      if (button.type !== "BUTTON") return; // Do something, not a button
+      if (button.style !== "LINK") return; // Do something, not a link button
+      url = linkSchema.safeParse(button.url);
+    } else {
+      url = linkSchema.safeParse(
+        interaction.options.get("message")!.message!.content
+      );
+    }
 
     if (!url.success) {
       throw new Error(

--- a/src/commands/context/play.ts
+++ b/src/commands/context/play.ts
@@ -35,7 +35,7 @@ export const playOnSpotify: MessageCommand = {
       "https://open.spotify.com/track/"
     )[1];
 
-    await JoshAPI.play(interaction.user!.id, songId);
+    await JoshAPI.playOnSpotify(interaction.user!.id, songId);
 
     const embed = new MessageEmbed()
       .setAuthor(

--- a/src/commands/context/play.ts
+++ b/src/commands/context/play.ts
@@ -35,7 +35,6 @@ export const playOnSpotify: MessageCommand = {
       "https://open.spotify.com/track/"
     )[1];
 
-    // TODO: add handling if errors
     await JoshAPI.play(interaction.user!.id, songId);
 
     const embed = new MessageEmbed()

--- a/src/commands/context/play.ts
+++ b/src/commands/context/play.ts
@@ -23,8 +23,8 @@ export const playOnSpotify: MessageCommand = {
 
     let url;
     if (
-      interaction.options.get("message")!.message!.author.id ===
-        "840585628408217610" &&
+        interaction.options.get("message")!.message!.author.id ===
+        interaction.client.user!.id &&
       interaction.options.get("message")!.message!.components
     ) {
       const button =

--- a/src/commands/context/queue.ts
+++ b/src/commands/context/queue.ts
@@ -1,0 +1,66 @@
+import { MessageCommand } from "../../types/command";
+import { JoshAPI } from "../../services/api/josh";
+import { MessageEmbed } from "discord.js";
+import { SongsApi } from "../../services/api/song";
+import * as z from "zod";
+import { voted } from "../../inhibitors/voted";
+
+const linkSchema = z.string().refine((x) => {
+    return (
+        x.includes("open.spotify.com/track") ||
+        x.includes("open.spotify.com/album") ||
+        x.includes("music.apple.com") ||
+        x.includes("soundcloud.com")
+    );
+}, "");
+
+export const queueOnSpotify: MessageCommand = {
+    name: "Add to Spotify Queue",
+    inhibitors: [voted],
+    type: "MESSAGE",
+    async run(interaction) {
+        await interaction.deferReply({ ephemeral: true });
+
+        let url;
+        if (
+            interaction.options.get("message")!.message!.author.id ===
+            interaction.client.user!.id &&
+            interaction.options.get("message")!.message!.components
+        ) {
+            const button =
+                interaction.options.get("message")!.message!.components![0]
+                    .components[0];
+            if (button.type !== "BUTTON") return; // Do something, not a button
+            if (button.style !== "LINK") return; // Do something, not a link button
+            url = linkSchema.safeParse(button.url);
+        } else {
+            url = linkSchema.safeParse(
+                interaction.options.get("message")!.message!.content
+            );
+        }
+
+        if (!url.success) {
+            throw new Error(
+                "I couldn't find a valid song link in this message - check and try again."
+            );
+        }
+
+        const song = await SongsApi.getLinks(url.data);
+        const songId = song.links!.spotify!.split(
+            "https://open.spotify.com/track/"
+        )[1];
+
+        await JoshAPI.queueOnSpotify(interaction.user!.id, songId);
+
+        const embed = new MessageEmbed()
+            .setAuthor(
+                `Added ${song.title} by ${song.artist} to your Spotify queue!`,
+                song.thumbnail ? song.thumbnail : ""
+            )
+            .setColor(0x212121);
+
+        await interaction.editReply({
+            embeds: [embed],
+        });
+    },
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,7 +11,7 @@ import { fm } from "./util/fm";
 import { profile } from "./settings/profile";
 import { playlist } from "./settings/playlist";
 import { getSong } from "./context/get-song";
-import { playlists } from "./context/spotify-add";
+import { playlists } from "./context/add";
 import { api } from "./settings/api";
 import { playOnSpotify } from "./context/play";
 import { source } from "./util/source";

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,6 +15,7 @@ import { playlists } from "./context/add";
 import { api } from "./settings/api";
 import { playOnSpotify } from "./context/play";
 import { source } from "./util/source";
+import {queueOnSpotify} from "./context/queue";
 
 export const chatCommands: ChatCommand[] = [
   ping,
@@ -31,7 +32,7 @@ export const chatCommands: ChatCommand[] = [
   source,
 ];
 
-export const messageCommands: MessageCommand[] = [playlists, playOnSpotify];
+export const messageCommands: MessageCommand[] = [playlists, playOnSpotify, queueOnSpotify];
 
 export const userCommands: UserCommand[] = [getSong];
 

--- a/src/commands/settings/api.ts
+++ b/src/commands/settings/api.ts
@@ -29,9 +29,9 @@ export const api: ChatCommand = {
     );
 
     if (options.subCommandName === "link") {
-      const user = await JoshAPI.user(interaction.member!.user.id);
+      const user = await JoshAPI.getUser(interaction.member!.user.id);
 
-      console.log(user)
+      console.log(user);
 
       const spotifyButton = new MessageButton()
         .setCustomId("button_spotify_link")
@@ -61,9 +61,8 @@ export const api: ChatCommand = {
         components: [row],
         ephemeral: true,
       });
-
     } else if (options.subCommandName === "unlink") {
-      const user = await JoshAPI.user(interaction.member!.user.id);
+      const user = await JoshAPI.getUser(interaction.member!.user.id);
 
       const spotifyButton = new MessageButton()
         .setCustomId("button_spotify_unlink")

--- a/src/commands/settings/api.ts
+++ b/src/commands/settings/api.ts
@@ -1,3 +1,4 @@
+import { MessageActionRow, MessageButton } from "discord.js";
 import { voted } from "../../inhibitors/voted";
 import { JoshAPI } from "../../services/api/josh";
 import { InteractionOptions } from "../../services/util/interactionOptions";
@@ -27,24 +28,35 @@ export const api: ChatCommand = {
     );
 
     if (options.subCommandName === "link") {
-      const request = await JoshAPI.link(
-        interaction.guild!.id,
-        interaction.channel!.id,
-        interaction.user.id
-      );
+      const user = await JoshAPI.user(interaction.member!.user.id);
+
+      console.log(user);
+
+      const row = new MessageActionRow().addComponents([
+        new MessageButton()
+          .setCustomId("button_spotify")
+          .setLabel("Spotify")
+          .setStyle("SUCCESS"),
+        new MessageButton()
+          .setCustomId("button_apple-music")
+          .setLabel("Apple Music")
+          .setStyle("DANGER"),
+      ]);
 
       await interaction.reply({
-        content: `[Click here to link your Spotify account to tunes.ninja!](${request})`,
-        ephemeral: true,
-      });
-    } else if (options.subCommandName === "unlink") {
-      const request = await JoshAPI.unlink(interaction.user.id);
-
-      if (!request) throw new Error("Internal error, do `/support");
-      await interaction.reply({
-        content: `If you had an account, it will be deleted!`,
+        content: "Select a platform to link!",
+        components: [row],
         ephemeral: true,
       });
     }
+    // } else if (options.subCommandName === "unlink") {
+    //   const request = await JoshAPI.unlink(interaction.user.id);
+
+    //   if (!request) throw new Error("Internal error, do `/support");
+    //   await interaction.reply({
+    //     content: `If you had an account, it will be deleted!`,
+    //     ephemeral: true,
+    //   });
+    // }
   },
 };

--- a/src/commands/settings/api.ts
+++ b/src/commands/settings/api.ts
@@ -1,6 +1,7 @@
 import { MessageActionRow, MessageButton } from "discord.js";
 import { voted } from "../../inhibitors/voted";
 import { JoshAPI } from "../../services/api/josh";
+import { PLATFORM_EMOJI } from "../../services/reply-song";
 import { InteractionOptions } from "../../services/util/interactionOptions";
 import { ChatCommand } from "../../types/command";
 
@@ -28,19 +29,22 @@ export const api: ChatCommand = {
     );
 
     if (options.subCommandName === "link") {
-      const user = await JoshAPI.user(interaction.member!.user.id);
+      // const user = await JoshAPI.user(interaction.member!.user.id);
 
-      console.log(user);
+      // console.log(user);
 
       const row = new MessageActionRow().addComponents([
         new MessageButton()
           .setCustomId("button_spotify")
           .setLabel("Spotify")
-          .setStyle("SUCCESS"),
+          .setStyle("SECONDARY")
+          .setEmoji(PLATFORM_EMOJI["spotify"]),
+
         new MessageButton()
           .setCustomId("button_apple-music")
           .setLabel("Apple Music")
-          .setStyle("DANGER"),
+          .setStyle("SECONDARY")
+          .setEmoji(PLATFORM_EMOJI["apple_music"]),
       ]);
 
       await interaction.reply({
@@ -49,6 +53,7 @@ export const api: ChatCommand = {
         ephemeral: true,
       });
     }
+
     // } else if (options.subCommandName === "unlink") {
     //   const request = await JoshAPI.unlink(interaction.user.id);
 

--- a/src/commands/settings/api.ts
+++ b/src/commands/settings/api.ts
@@ -32,7 +32,7 @@ export const api: ChatCommand = {
       const user = await JoshAPI.user(interaction.member!.user.id);
 
       const spotifyButton = new MessageButton()
-        .setCustomId("button_spotify")
+        .setCustomId("button_spotify_link")
         .setLabel("Spotify")
         .setStyle("SECONDARY")
         .setEmoji(PLATFORM_EMOJI["spotify"]);
@@ -41,7 +41,7 @@ export const api: ChatCommand = {
         : spotifyButton.setDisabled(false);
 
       const appleMusicButton = new MessageButton()
-        .setCustomId("button_apple-music")
+        .setCustomId("button_apple-music_link")
         .setLabel("Apple Music")
         .setStyle("SECONDARY")
         .setEmoji(PLATFORM_EMOJI["apple_music"]);
@@ -59,16 +59,38 @@ export const api: ChatCommand = {
         components: [row],
         ephemeral: true,
       });
+
+    } else if (options.subCommandName === "unlink") {
+      const user = await JoshAPI.user(interaction.member!.user.id);
+
+      const spotifyButton = new MessageButton()
+        .setCustomId("button_spotify_unlink")
+        .setLabel("Spotify")
+        .setStyle("SECONDARY")
+        .setEmoji(PLATFORM_EMOJI["spotify"]);
+      user.services.spotify
+        ? spotifyButton.setDisabled(false)
+        : spotifyButton.setDisabled(true).setLabel("Spotify (unlinked)");
+
+      const appleMusicButton = new MessageButton()
+        .setCustomId("button_apple-music_unlink")
+        .setLabel("Apple Music")
+        .setStyle("SECONDARY")
+        .setEmoji(PLATFORM_EMOJI["apple_music"]);
+      user.services.appleMusic
+        ? appleMusicButton.setDisabled(false)
+        : appleMusicButton.setDisabled(true).setLabel("Apple Music (unlinked)");
+
+      const row = new MessageActionRow().addComponents([
+        spotifyButton,
+        appleMusicButton,
+      ]);
+
+      await interaction.reply({
+        content: "Select a platform to unlink!",
+        components: [row],
+        ephemeral: true,
+      });
     }
-
-    // } else if (options.subCommandName === "unlink") {
-    //   const request = await JoshAPI.unlink(interaction.user.id);
-
-    //   if (!request) throw new Error("Internal error, do `/support");
-    //   await interaction.reply({
-    //     content: `If you had an account, it will be deleted!`,
-    //     ephemeral: true,
-    //   });
-    // }
   },
 };

--- a/src/commands/settings/api.ts
+++ b/src/commands/settings/api.ts
@@ -31,6 +31,8 @@ export const api: ChatCommand = {
     if (options.subCommandName === "link") {
       const user = await JoshAPI.user(interaction.member!.user.id);
 
+      console.log(user)
+
       const spotifyButton = new MessageButton()
         .setCustomId("button_spotify_link")
         .setLabel("Spotify")

--- a/src/commands/settings/api.ts
+++ b/src/commands/settings/api.ts
@@ -29,22 +29,29 @@ export const api: ChatCommand = {
     );
 
     if (options.subCommandName === "link") {
-      // const user = await JoshAPI.user(interaction.member!.user.id);
+      const user = await JoshAPI.user(interaction.member!.user.id);
 
-      // console.log(user);
+      const spotifyButton = new MessageButton()
+        .setCustomId("button_spotify")
+        .setLabel("Spotify")
+        .setStyle("SECONDARY")
+        .setEmoji(PLATFORM_EMOJI["spotify"]);
+      user.services.spotify
+        ? spotifyButton.setDisabled(true).setLabel("Spotify (linked)")
+        : spotifyButton.setDisabled(false);
+
+      const appleMusicButton = new MessageButton()
+        .setCustomId("button_apple-music")
+        .setLabel("Apple Music")
+        .setStyle("SECONDARY")
+        .setEmoji(PLATFORM_EMOJI["apple_music"]);
+      user.services.appleMusic
+        ? appleMusicButton.setDisabled(true).setLabel("Apple Music (linked)")
+        : appleMusicButton.setDisabled(false);
 
       const row = new MessageActionRow().addComponents([
-        new MessageButton()
-          .setCustomId("button_spotify")
-          .setLabel("Spotify")
-          .setStyle("SECONDARY")
-          .setEmoji(PLATFORM_EMOJI["spotify"]),
-
-        new MessageButton()
-          .setCustomId("button_apple-music")
-          .setLabel("Apple Music")
-          .setStyle("SECONDARY")
-          .setEmoji(PLATFORM_EMOJI["apple_music"]),
+        spotifyButton,
+        appleMusicButton,
       ]);
 
       await interaction.reply({

--- a/src/commands/settings/playlist.ts
+++ b/src/commands/settings/playlist.ts
@@ -1,148 +1,162 @@
 import {
-    CommandInteraction,
-    Constants,
-    GuildMember,
-    MessageActionRow,
-    MessageButton, MessageSelectMenu,
-    Permissions,
-    User,
+  CommandInteraction,
+  Constants,
+  GuildMember,
+  MessageActionRow,
+  MessageButton,
+  MessageSelectMenu,
+  Permissions,
+  User,
 } from "discord.js";
-import {botAdmins} from "../../inhibitors/botAdmins";
-import {JoshAPI} from "../../services/api/josh";
-import {prisma} from "../../services/prisma";
-import {InteractionOptions} from "../../services/util/interactionOptions";
-import {StandardEmbed} from "../../structs/standard-embed";
-import {ChatCommand} from "../../types/command";
-import {PLATFORM_EMOJI} from "../../services/reply-song";
-import {platforms} from "../../services/events/interaction";
+import { botAdmins } from "../../inhibitors/botAdmins";
+import { JoshAPI } from "../../services/api/josh";
+import { prisma } from "../../services/prisma";
+import { InteractionOptions } from "../../services/util/interactionOptions";
+import { StandardEmbed } from "../../structs/standard-embed";
+import { ChatCommand } from "../../types/command";
+import { PLATFORM_EMOJI } from "../../services/reply-song";
+import { platforms } from "../../services/events/interaction";
 
 export const playlist: ChatCommand = {
-    name: "playlist",
-    description: "Tunes.ninja playlist API.",
-    type: "CHAT_INPUT",
-    options: [
+  name: "playlist",
+  description: "Tunes.ninja playlist API.",
+  type: "CHAT_INPUT",
+  options: [
+    {
+      name: "sync",
+      description:
+        "Sync Spotify songs sent in this channel to your server's playlist.",
+      type: "SUB_COMMAND",
+      options: [
         {
-            name: "sync",
-            description: "Sync Spotify songs sent in this channel to your server's playlist.",
-            type: "SUB_COMMAND",
-            options: [{
-                name: "platform",
-                description: "Platform to create the playlist on.",
-                type: "STRING",
-                required: true,
-                choices: [{
-                    name: "Spotify",
-                    value: "spotify"
-                }, {
-                    name: "Apple Music",
-                    value: "apple-music"
-                }]
-            }],
+          name: "platform",
+          description: "Platform to create the playlist on.",
+          type: "STRING",
+          required: true,
+          choices: [
+            {
+              name: "Spotify",
+              value: "spotify",
+            },
+            {
+              name: "Apple Music",
+              value: "apple-music",
+            },
+          ],
         },
-        {
-            name: "unsync",
-            description: "Unsync this channel from the playlist.",
-            type: "SUB_COMMAND",
-        },
-    ],
-    inhibitors: [botAdmins],
-    async run(interaction) {
-        await interaction.deferReply({
-            ephemeral: true
+      ],
+    },
+    {
+      name: "unsync",
+      description: "Unsync this channel from the playlist.",
+      type: "SUB_COMMAND",
+    },
+  ],
+  inhibitors: [botAdmins],
+  async run(interaction) {
+    await interaction.deferReply();
+
+    const options = new InteractionOptions(
+      interaction.options.data as unknown as InteractionOptions[]
+    );
+
+    if (options.subCommandName === "sync") {
+      const member = interaction.member as GuildMember;
+
+      const canManageServer = member.permissions.has(
+        Permissions.FLAGS.MANAGE_GUILD
+      );
+
+      if (!canManageServer) {
+        throw new Error("You do not have permission to use this command.");
+      }
+
+      const linked = await JoshAPI.getLinkedPlaylists(interaction.channel!.id);
+
+      console.log(linked);
+
+      const user = await JoshAPI.getUser(interaction.user.id);
+
+      let playlist: any;
+      let platform: string;
+
+      if (user.services.spotify) {
+        playlist = await JoshAPI.createPlaylist(interaction.user, "spotify");
+        platform = "spotify";
+      } else if (user.services.appleMusic) {
+        playlist = await JoshAPI.createPlaylist(
+          interaction.user,
+          "apple-music"
+        );
+        platform = "apple-music";
+      } else if (user.services.appleMusic && user.services.spotify) {
+        platform = "need to handle";
+        throw new Error("need to handle multiple platforms");
+      }
+
+      if (!playlist)
+        throw new Error("Internal error, please report this using `/support`.");
+
+      if (playlist.status) {
+        await prisma.joshChannel.create({
+          data: {
+            id: interaction.channel!.id,
+            platform: platform!, // TODO: remove this !
+            playlistID: playlist.detail.playlistID,
+          },
         });
 
-        const options = new InteractionOptions(
-            interaction.options.data as unknown as InteractionOptions[]
+        await JoshAPI.syncPlaylist(
+          interaction.guild!.id,
+          interaction.channel!.id,
+          interaction.user!.id,
+          platform!, // TODO: remove this !
+          playlist.detail.playlistID
         );
 
-        if (options.subCommandName === "sync") {
-            const platform = "apple-music"
+        const embed = new StandardEmbed(interaction.user as User)
+          .setDescription(
+            `All links in this channel will now be added to your shared playlist! Open the playlist by clicking the button below.`
+          )
+          .setColor(Constants.Colors.GREEN);
 
-            const member = interaction.member as GuildMember;
-
-            const canManageServer = member.permissions.has(Permissions.FLAGS.MANAGE_GUILD);
-
-            if (!canManageServer) {
-                throw new Error("You do not have permission to use this command.");
-            }
-
-            const playlists = await JoshAPI.getPlaylists(interaction.user.id, platforms[interaction.options.get('platform')!.value!.toString()]
-            );
-
-            const row = new MessageActionRow().addComponents(
-                new MessageSelectMenu()
-                    .setCustomId(`select_${interaction.user.id}_${platform}`)
-                    .setPlaceholder(`Select a ${platforms[platform]
-                        .split("-")
-                        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
-                        .join(" ")} playlist from the list`)
-                    .addOptions(
-                        playlists.playlists.map(
-                            (p: { playlist_display_name: string; playlist_id: string }) => {
-                                return {
-                                    label: p.playlist_display_name,
-                                    value: `_${p.playlist_id}_${platform}`,
-                                    emoji: PLATFORM_EMOJI[platform]
-                                };
-                            }
-                        )
-                    )
-            );
-
-            // const request = await JoshAPI.playlist(
-            //   interaction.guild!.id,
-            //   interaction.channel!.id,
-            //   interaction.user.id
-            // );
-            //
-            // if (request.linked) {
-            //   await prisma.joshChannel.create({
-            //     data: {
-            //       id: interaction.channel!.id,
-            //       premium: false,
-            //     },
-            //   });
-            //
-            //   const embed = new StandardEmbed(interaction.user as User)
-            //     .setDescription(
-            //       `All Spotify links in this channel will now be added to your shared playlist! Open the playlist by clicking the button below.`
-            //     )
-            //     .setColor(Constants.Colors.GREEN);
-            //
-            //   const row = new MessageActionRow();
-            //   row.addComponents(
-            //     new MessageButton().setStyle("LINK").setURL(request.playlistUrl).setLabel("Open Playlist")
-            //   );
-            //   await interaction.reply({embeds: [embed], components: [row]});
-            // } else if (request.playlistUrl) {
-            //   const embed = new StandardEmbed(interaction.user as User)
-            //     .setDescription(
-            //       `This channel already has a synced playlist! Click the button below to open it!`
-            //     )
-            //     .setColor(Constants.Colors.GREEN);
-            //
-            //   const row = new MessageActionRow();
-            //   row.addComponents(
-            //     new MessageButton().setStyle("LINK").setURL(request.playlistUrl).setLabel("Open Playlist")
-            //   );
-            //   await interaction.reply({embeds: [embed], components: [row]});
-            // }
-        } else if (options.subCommandName === "unsync") {
-            const member = interaction.member as GuildMember;
-
-            const canManageServer = member.permissions.has(Permissions.FLAGS.MANAGE_GUILD);
-
-            if (!canManageServer) {
-                throw new Error("You do not have permission to use this command.");
-            }
-
-            const request = await JoshAPI.delete(interaction.channel!.id);
-
-            if (request.status) {
-                await interaction.reply("👌");
-            } else if (request.detail.code === "SP001") {
-                await interaction.reply("No synced playlist was found for this channel!");
-            }
-        }
-    },
+        const row = new MessageActionRow();
+        row.addComponents(
+          new MessageButton()
+            .setStyle("LINK")
+            .setURL(
+              `${
+                platform! === "apple-music"
+                  ? `https://music.apple.com/playlist/${playlist.detail.playlistID}`
+                  : `https://open.spotify.com/playlist/${playlist.detail.playlistID}`
+              }`
+            )
+            .setLabel("Open Playlist")
+            .setEmoji(PLATFORM_EMOJI[platform!]) // TODO: remove this !
+        );
+        await interaction.editReply({ embeds: [embed], components: [row] });
+      }
+    } else if (options.subCommandName === "unsync") {
+      // TODO: probably need to write all of this innit
+      // const member = interaction.member as GuildMember;
+      //
+      // const canManageServer = member.permissions.has(
+      //   Permissions.FLAGS.MANAGE_GUILD
+      // );
+      //
+      // if (!canManageServer) {
+      //   throw new Error("You do not have permission to use this command.");
+      // }
+      //
+      // const request = await JoshAPI.delete(interaction.channel!.id);
+      //
+      // if (request.status) {
+      //   await interaction.reply("👌");
+      // } else if (request.detail.code === "SP001") {
+      //   await interaction.reply(
+      //     "No synced playlist was found for this channel!"
+      //   );
+      // }
+    }
+  },
 };

--- a/src/commands/settings/playlist.ts
+++ b/src/commands/settings/playlist.ts
@@ -75,16 +75,119 @@ export const playlist: ChatCommand = {
         throw new Error("You do not have permission to use this command.");
       }
 
-      const existing = await prisma.joshChannel.findUnique({
-        where: {
-          id: interaction.channel!.id,
-        },
-      });
+      // if (existing) {
+      //   const embed = new StandardEmbed(interaction.user as User)
+      //     .setDescription(
+      //       `This channel already has a synced playlist! Click the button below to open it!`
+      //     )
+      //     .setColor(Constants.Colors.GREEN);
+      //
+      //   const row = new MessageActionRow();
+      //   row.addComponents(
+      //     new MessageButton()
+      //       .setStyle("LINK")
+      //       .setStyle("LINK")
+      //       .setURL(
+      //         `${
+      //           existing.platform === "apple-music"
+      //             ? `https://music.apple.com/playlist/${existing.playlistID}`
+      //             : `https://open.spotify.com/playlist/${existing.playlistID}`
+      //         }`
+      //       )
+      //       .setLabel("Open Playlist")
+      //       .setEmoji(PLATFORM_EMOJI[existing.platform]) // TODO: remove this !
+      //   );
+      //   await interaction.editReply({ embeds: [embed], components: [row] });
+      // } else {
+      const user = await JoshAPI.getUser(interaction.user.id);
 
-      if (existing) {
+      let playlist: any;
+      let platform: string;
+
+      if (!user.services.spotify && !user.services.appleMusic) {
+        throw new Error("No services are linked! Do `/api link` to link them."); // TODO: standardize these errors
+      }
+
+      // TODO: this needs to be written to be way cleaner
+      if (user.services.spotify && !user.services.appleMusic) {
+        playlist = await JoshAPI.createPlaylist(interaction.user, "spotify");
+        platform = "spotify";
+      } else if (user.services.appleMusic && !user.services.spotify) {
+        playlist = await JoshAPI.createPlaylist(
+          interaction.user,
+          "apple-music"
+        );
+        platform = "apple-music";
+      } else if (user.services.appleMusic && user.services.spotify) {
+        const spotifyButton = new MessageButton()
+          .setCustomId("button_spotify_playlistSelect")
+          .setLabel("Spotify")
+          .setStyle("SECONDARY")
+          .setEmoji(PLATFORM_EMOJI["spotify"]);
+
+        const appleMusicButton = new MessageButton()
+          .setCustomId("button_apple-music_playlistSelect")
+          .setLabel("Apple Music")
+          .setStyle("SECONDARY")
+          .setEmoji(PLATFORM_EMOJI["apple_music"]);
+
+        const row = new MessageActionRow().addComponents([
+          spotifyButton,
+          appleMusicButton,
+        ]);
+
+        const msg = await interaction.editReply({
+          content:
+            "You have multiple platforms linked - which would you like to create the playlist on?",
+          components: [row],
+        });
+
+        const filter = (i: any) => {
+          return i.user.id === interaction.user.id;
+        };
+
+        await (msg as Message)
+          .awaitMessageComponent({
+            filter,
+            componentType: "BUTTON",
+            time: 10000,
+          })
+          .then(async (interaction) => {
+            playlist = await JoshAPI.createPlaylist(
+              interaction.user,
+              interaction.customId.split("_")[1]
+            );
+            platform = interaction.customId.split("_")[1];
+            await interaction.deferUpdate();
+          })
+          .catch(async () => {
+            await interaction.deleteReply();
+          });
+      }
+
+      if (!playlist)
+        throw new Error("Internal error, please report this using `/support`.");
+
+      if (playlist.status) {
+        await prisma.joshChannel.create({
+          data: {
+            id: interaction.channel!.id,
+            platform: platform!, // TODO: remove this !
+            playlistID: playlist.detail.playlistID,
+          },
+        });
+
+        await JoshAPI.syncPlaylist(
+          interaction.guild!.id,
+          interaction.channel!.id,
+          interaction.user!.id,
+          platform!, // TODO: remove this !
+          playlist.detail.playlistID
+        );
+
         const embed = new StandardEmbed(interaction.user as User)
           .setDescription(
-            `This channel already has a synced playlist! Click the button below to open it!`
+            `All links in this channel will now be added to your shared playlist! Open the playlist by clicking the button below.`
           )
           .setColor(Constants.Colors.GREEN);
 
@@ -92,135 +195,21 @@ export const playlist: ChatCommand = {
         row.addComponents(
           new MessageButton()
             .setStyle("LINK")
-            .setStyle("LINK")
             .setURL(
               `${
-                existing.platform === "apple-music"
-                  ? `https://music.apple.com/playlist/${existing.playlistID}`
-                  : `https://open.spotify.com/playlist/${existing.playlistID}`
+                platform! === "apple-music"
+                  ? `https://music.apple.com/playlist/${playlist.detail.playlistID}`
+                  : `https://open.spotify.com/playlist/${playlist.detail.playlistID}`
               }`
             )
             .setLabel("Open Playlist")
-            .setEmoji(PLATFORM_EMOJI[existing.platform]) // TODO: remove this !
+            .setEmoji(PLATFORM_EMOJI[platform!]) // TODO: remove this !
         );
-        await interaction.editReply({ embeds: [embed], components: [row] });
-      } else {
-        const user = await JoshAPI.getUser(interaction.user.id);
-
-        let playlist: any;
-        let platform: string;
-
-        if (!user.services.spotify && !user.services.appleMusic) {
-          throw new Error(
-            "No services are linked! Do `/api link` to link them."
-          ); // TODO: standardize these errors
-        }
-
-        // TODO: this needs to be written to be way cleaner
-        if (user.services.spotify && !user.services.appleMusic) {
-          playlist = await JoshAPI.createPlaylist(interaction.user, "spotify");
-          platform = "spotify";
-        } else if (user.services.appleMusic && !user.services.spotify) {
-          playlist = await JoshAPI.createPlaylist(
-            interaction.user,
-            "apple-music"
-          );
-          platform = "apple-music";
-        } else if (user.services.appleMusic && user.services.spotify) {
-          const spotifyButton = new MessageButton()
-            .setCustomId("button_spotify_playlistSelect")
-            .setLabel("Spotify")
-            .setStyle("SECONDARY")
-            .setEmoji(PLATFORM_EMOJI["spotify"]);
-
-          const appleMusicButton = new MessageButton()
-            .setCustomId("button_apple-music_playlistSelect")
-            .setLabel("Apple Music")
-            .setStyle("SECONDARY")
-            .setEmoji(PLATFORM_EMOJI["apple_music"]);
-
-          const row = new MessageActionRow().addComponents([
-            spotifyButton,
-            appleMusicButton,
-          ]);
-
-          const msg = await interaction.editReply({
-            content:
-              "You have multiple platforms linked - which would you like to create the playlist on?",
-            components: [row],
-          });
-
-          const filter = (i: any) => {
-            return i.user.id === interaction.user.id;
-          };
-
-          await (msg as Message)
-            .awaitMessageComponent({
-              filter,
-              componentType: "BUTTON",
-              time: 10000,
-            })
-            .then(async (interaction) => {
-              playlist = await JoshAPI.createPlaylist(
-                interaction.user,
-                interaction.customId.split("_")[1]
-              );
-              platform = interaction.customId.split("_")[1];
-              await interaction.deferUpdate();
-            })
-            .catch(async () => {
-              await interaction.deleteReply();
-            });
-        }
-
-        if (!playlist)
-          throw new Error(
-            "Internal error, please report this using `/support`."
-          );
-
-        if (playlist.status) {
-          await prisma.joshChannel.create({
-            data: {
-              id: interaction.channel!.id,
-              platform: platform!, // TODO: remove this !
-              playlistID: playlist.detail.playlistID,
-            },
-          });
-
-          await JoshAPI.syncPlaylist(
-            interaction.guild!.id,
-            interaction.channel!.id,
-            interaction.user!.id,
-            platform!, // TODO: remove this !
-            playlist.detail.playlistID
-          );
-
-          const embed = new StandardEmbed(interaction.user as User)
-            .setDescription(
-              `All links in this channel will now be added to your shared playlist! Open the playlist by clicking the button below.`
-            )
-            .setColor(Constants.Colors.GREEN);
-
-          const row = new MessageActionRow();
-          row.addComponents(
-            new MessageButton()
-              .setStyle("LINK")
-              .setURL(
-                `${
-                  platform! === "apple-music"
-                    ? `https://music.apple.com/playlist/${playlist.detail.playlistID}`
-                    : `https://open.spotify.com/playlist/${playlist.detail.playlistID}`
-                }`
-              )
-              .setLabel("Open Playlist")
-              .setEmoji(PLATFORM_EMOJI[platform!]) // TODO: remove this !
-          );
-          await interaction.editReply({
-            embeds: [embed],
-            components: [row],
-            content: null,
-          });
-        }
+        await interaction.editReply({
+          embeds: [embed],
+          components: [row],
+          content: null,
+        });
       }
     } else if (options.subCommandName === "unsync") {
       // TODO: probably need to write all of this innit
@@ -234,30 +223,81 @@ export const playlist: ChatCommand = {
         throw new Error("You do not have permission to use this command.");
       }
 
-      const existing = await prisma.joshChannel.findUnique({
-        where: {
-          id: interaction.channel!.id,
-        },
-      });
+      const synced = await JoshAPI.getLinkedPlaylists(interaction.channel!.id);
 
-      if (!existing) {
+      if (
+        !synced.playlists.spotify.length &&
+        !synced.playlists.appleMusic.length
+      ) {
         throw new Error(
-          "No synced playlist found! Do `/playlist sync` to start."
+          "No synced playlists found! Do `/playlist sync` to start."
         );
       }
 
-      const response = await JoshAPI.unsyncPlaylist(
-        interaction.channel!.id,
-        existing.platform
-      );
-      if (response.status) {
-        await interaction.editReply("Your playlist has been unlinked!");
+      const menu = new MessageSelectMenu()
+        .setCustomId(`select_${interaction.user.id}_unsync`)
+        .setPlaceholder(`Select a playlist from the list`);
+
+      for (const service in synced.playlists) {
+        synced.playlists[service].map(
+          (p: {
+            internalID: string;
+            playlistLinkedPlatformUniqueID: string;
+          }) => {
+            return menu.addOptions({
+              label: "Placeholder",
+              value: `${service}_${p.playlistLinkedPlatformUniqueID}`,
+              description: `ID: ${p.playlistLinkedPlatformUniqueID}`,
+              emoji: PLATFORM_EMOJI[service],
+            });
+          }
+        );
       }
-      await prisma.joshChannel.delete({
-        where: {
-          id: interaction.channel!.id,
-        },
+
+      const row = new MessageActionRow().addComponents(menu);
+
+      const msg = await interaction.editReply({
+        content: "Select a playlist to unsync from this channel.",
+        components: [row],
       });
+
+      const filter = (i: any) => {
+        return i.user.id === interaction.user.id;
+      };
+
+      await (msg as Message)
+        .awaitMessageComponent({
+          filter,
+          componentType: "SELECT_MENU",
+          time: 10000,
+        })
+        .then(async (interaction) => {
+          await interaction.deferUpdate();
+          const platform = interaction.values[0].split("_")[0];
+          const id = interaction.values[0].split("_")[1];
+
+          console.log(platform, id);
+
+          const response = await JoshAPI.unsyncPlaylist(
+            interaction.channel!.id,
+            platforms[platform]
+          );
+
+          if (response.status) {
+            await interaction.editReply({
+              content: "Your playlist has been unlinked!",
+              components: [],
+            });
+          }
+          await prisma.joshChannel.delete({
+            where: {
+              playlistID: id,
+            },
+          });
+        })
+        .catch(async () => {
+          await interaction.deleteReply();
+        });
     }
   },
 };

--- a/src/commands/settings/playlist.ts
+++ b/src/commands/settings/playlist.ts
@@ -75,37 +75,13 @@ export const playlist: ChatCommand = {
         throw new Error("You do not have permission to use this command.");
       }
 
-      // if (existing) {
-      //   const embed = new StandardEmbed(interaction.user as User)
-      //     .setDescription(
-      //       `This channel already has a synced playlist! Click the button below to open it!`
-      //     )
-      //     .setColor(Constants.Colors.GREEN);
-      //
-      //   const row = new MessageActionRow();
-      //   row.addComponents(
-      //     new MessageButton()
-      //       .setStyle("LINK")
-      //       .setStyle("LINK")
-      //       .setURL(
-      //         `${
-      //           existing.platform === "apple-music"
-      //             ? `https://music.apple.com/playlist/${existing.playlistID}`
-      //             : `https://open.spotify.com/playlist/${existing.playlistID}`
-      //         }`
-      //       )
-      //       .setLabel("Open Playlist")
-      //       .setEmoji(PLATFORM_EMOJI[existing.platform]) // TODO: remove this !
-      //   );
-      //   await interaction.editReply({ embeds: [embed], components: [row] });
-      // } else {
       const user = await JoshAPI.getUser(interaction.user.id);
 
       let playlist: any;
       let platform: string;
 
       if (!user.services.spotify && !user.services.appleMusic) {
-        throw new Error("No services are linked! Do `/api link` to link them."); // TODO: standardize these errors
+        throw new Error("No services are linked! Do `/api link` to link them.");
       }
 
       // TODO: this needs to be written to be way cleaner
@@ -275,8 +251,6 @@ export const playlist: ChatCommand = {
           await interaction.deferUpdate();
           const platform = interaction.values[0].split("_")[0];
           const id = interaction.values[0].split("_")[1];
-
-          console.log(platform, id);
 
           const response = await JoshAPI.unsyncPlaylist(
             interaction.channel!.id,

--- a/src/commands/settings/playlist.ts
+++ b/src/commands/settings/playlist.ts
@@ -217,11 +217,11 @@ export const playlist: ChatCommand = {
       for (const service in synced.playlists) {
         synced.playlists[service].map(
           (p: {
-            internalID: string;
+            playlistTitle: string;
             playlistLinkedPlatformUniqueID: string;
           }) => {
             return menu.addOptions({
-              label: "Placeholder",
+              label: `${p.playlistTitle}`,
               value: `${service}_${p.playlistLinkedPlatformUniqueID}`,
               description: `ID: ${p.playlistLinkedPlatformUniqueID}`,
               emoji: PLATFORM_EMOJI[service],
@@ -269,7 +269,7 @@ export const playlist: ChatCommand = {
             },
           });
         })
-        .catch(async () => {
+        .catch(async (e) => {
           await interaction.deleteReply();
         });
     }

--- a/src/commands/settings/playlist.ts
+++ b/src/commands/settings/playlist.ts
@@ -1,10 +1,11 @@
 import {
-  Constants,
-  GuildMember,
-  MessageActionRow,
-  MessageButton,
-  Permissions,
-  User,
+    CommandInteraction,
+    Constants,
+    GuildMember,
+    MessageActionRow,
+    MessageButton, MessageSelectMenu,
+    Permissions,
+    User,
 } from "discord.js";
 import {botAdmins} from "../../inhibitors/botAdmins";
 import {JoshAPI} from "../../services/api/josh";
@@ -12,92 +13,136 @@ import {prisma} from "../../services/prisma";
 import {InteractionOptions} from "../../services/util/interactionOptions";
 import {StandardEmbed} from "../../structs/standard-embed";
 import {ChatCommand} from "../../types/command";
+import {PLATFORM_EMOJI} from "../../services/reply-song";
+import {platforms} from "../../services/events/interaction";
 
 export const playlist: ChatCommand = {
-  name: "playlist",
-  description: "Tunes.ninja playlist API.",
-  type: "CHAT_INPUT",
-  options: [
-    {
-      name: "sync",
-      description: "Sync Spotify songs sent in this channel to your server's playlist.",
-      type: "SUB_COMMAND",
-    },
-    {
-      name: "unsync",
-      description: "Unsync this channel from the playlist.",
-      type: "SUB_COMMAND",
-    },
-  ],
-  inhibitors: [botAdmins],
-  async run(interaction) {
-    const options = new InteractionOptions(
-      interaction.options.data as unknown as InteractionOptions[]
-    );
-
-    if (options.subCommandName === "sync") {
-      const member = interaction.member as GuildMember;
-
-      const canManageServer = member.permissions.has(Permissions.FLAGS.MANAGE_GUILD);
-
-      if (!canManageServer) {
-        throw new Error("You do not have permission to use this command.");
-      }
-
-      const request = await JoshAPI.playlist(
-        interaction.guild!.id,
-        interaction.channel!.id,
-        interaction.user.id
-      );
-
-      if (request.linked) {
-        await prisma.joshChannel.create({
-          data: {
-            id: interaction.channel!.id,
-            premium: false,
-          },
+    name: "playlist",
+    description: "Tunes.ninja playlist API.",
+    type: "CHAT_INPUT",
+    options: [
+        {
+            name: "sync",
+            description: "Sync Spotify songs sent in this channel to your server's playlist.",
+            type: "SUB_COMMAND",
+            options: [{
+                name: "platform",
+                description: "Platform to create the playlist on.",
+                type: "STRING",
+                required: true,
+                choices: [{
+                    name: "Spotify",
+                    value: "spotify"
+                }, {
+                    name: "Apple Music",
+                    value: "apple-music"
+                }]
+            }],
+        },
+        {
+            name: "unsync",
+            description: "Unsync this channel from the playlist.",
+            type: "SUB_COMMAND",
+        },
+    ],
+    inhibitors: [botAdmins],
+    async run(interaction) {
+        await interaction.deferReply({
+            ephemeral: true
         });
 
-        const embed = new StandardEmbed(interaction.user as User)
-          .setDescription(
-            `All Spotify links in this channel will now be added to your shared playlist! Open the playlist by clicking the button below.`
-          )
-          .setColor(Constants.Colors.GREEN);
-
-        const row = new MessageActionRow();
-        row.addComponents(
-          new MessageButton().setStyle("LINK").setURL(request.playlistUrl).setLabel("Open Playlist")
+        const options = new InteractionOptions(
+            interaction.options.data as unknown as InteractionOptions[]
         );
-        await interaction.reply({embeds: [embed], components: [row]});
-      } else if (request.playlistUrl) {
-        const embed = new StandardEmbed(interaction.user as User)
-          .setDescription(
-            `This channel already has a synced playlist! Click the button below to open it!`
-          )
-          .setColor(Constants.Colors.GREEN);
 
-        const row = new MessageActionRow();
-        row.addComponents(
-          new MessageButton().setStyle("LINK").setURL(request.playlistUrl).setLabel("Open Playlist")
-        );
-        await interaction.reply({embeds: [embed], components: [row]});
-      }
-    } else if (options.subCommandName === "unsync") {
-      const member = interaction.member as GuildMember;
+        if (options.subCommandName === "sync") {
+            const platform = "apple-music"
 
-      const canManageServer = member.permissions.has(Permissions.FLAGS.MANAGE_GUILD);
+            const member = interaction.member as GuildMember;
 
-      if (!canManageServer) {
-        throw new Error("You do not have permission to use this command.");
-      }
+            const canManageServer = member.permissions.has(Permissions.FLAGS.MANAGE_GUILD);
 
-      const request = await JoshAPI.delete(interaction.channel!.id);
+            if (!canManageServer) {
+                throw new Error("You do not have permission to use this command.");
+            }
 
-      if (request.status) {
-        await interaction.reply("👌");
-      } else if (request.detail.code === "SP001") {
-        await interaction.reply("No synced playlist was found for this channel!");
-      }
-    }
-  },
+            const playlists = await JoshAPI.getPlaylists(interaction.user.id, platforms[interaction.options.get('platform')!.value!.toString()]
+            );
+
+            const row = new MessageActionRow().addComponents(
+                new MessageSelectMenu()
+                    .setCustomId(`select_${interaction.user.id}_${platform}`)
+                    .setPlaceholder(`Select a ${platforms[platform]
+                        .split("-")
+                        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+                        .join(" ")} playlist from the list`)
+                    .addOptions(
+                        playlists.playlists.map(
+                            (p: { playlist_display_name: string; playlist_id: string }) => {
+                                return {
+                                    label: p.playlist_display_name,
+                                    value: `_${p.playlist_id}_${platform}`,
+                                    emoji: PLATFORM_EMOJI[platform]
+                                };
+                            }
+                        )
+                    )
+            );
+
+            // const request = await JoshAPI.playlist(
+            //   interaction.guild!.id,
+            //   interaction.channel!.id,
+            //   interaction.user.id
+            // );
+            //
+            // if (request.linked) {
+            //   await prisma.joshChannel.create({
+            //     data: {
+            //       id: interaction.channel!.id,
+            //       premium: false,
+            //     },
+            //   });
+            //
+            //   const embed = new StandardEmbed(interaction.user as User)
+            //     .setDescription(
+            //       `All Spotify links in this channel will now be added to your shared playlist! Open the playlist by clicking the button below.`
+            //     )
+            //     .setColor(Constants.Colors.GREEN);
+            //
+            //   const row = new MessageActionRow();
+            //   row.addComponents(
+            //     new MessageButton().setStyle("LINK").setURL(request.playlistUrl).setLabel("Open Playlist")
+            //   );
+            //   await interaction.reply({embeds: [embed], components: [row]});
+            // } else if (request.playlistUrl) {
+            //   const embed = new StandardEmbed(interaction.user as User)
+            //     .setDescription(
+            //       `This channel already has a synced playlist! Click the button below to open it!`
+            //     )
+            //     .setColor(Constants.Colors.GREEN);
+            //
+            //   const row = new MessageActionRow();
+            //   row.addComponents(
+            //     new MessageButton().setStyle("LINK").setURL(request.playlistUrl).setLabel("Open Playlist")
+            //   );
+            //   await interaction.reply({embeds: [embed], components: [row]});
+            // }
+        } else if (options.subCommandName === "unsync") {
+            const member = interaction.member as GuildMember;
+
+            const canManageServer = member.permissions.has(Permissions.FLAGS.MANAGE_GUILD);
+
+            if (!canManageServer) {
+                throw new Error("You do not have permission to use this command.");
+            }
+
+            const request = await JoshAPI.delete(interaction.channel!.id);
+
+            if (request.status) {
+                await interaction.reply("👌");
+            } else if (request.detail.code === "SP001") {
+                await interaction.reply("No synced playlist was found for this channel!");
+            }
+        }
+    },
 };

--- a/src/commands/util/stats.ts
+++ b/src/commands/util/stats.ts
@@ -1,8 +1,14 @@
-import {GuildMember, User} from "discord.js";
+import {GuildMember, MessageEmbed, User} from "discord.js";
 import {contributors} from "../../constants";
-import {countProfiles, countSearches} from "../../services/util/count";
+import {countGuilds, countPlaylists, countProfiles, countSearches, countVotes} from "../../services/util/count";
 import {StandardEmbed} from "../../structs/standard-embed";
 import {ChatCommand} from "../../types/command";
+import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+dayjs.extend(duration);
+dayjs.extend(relativeTime);
 
 export const stats: ChatCommand = {
   name: "stats",
@@ -11,33 +17,52 @@ export const stats: ChatCommand = {
   type: "CHAT_INPUT",
 
   async run(interaction) {
-    const count = await countSearches();
+    await interaction.deferReply({ephemeral: true})
+    const songs = await countSearches();
     const profiles = await countProfiles();
+    const playlists = await countPlaylists();
+    const guilds = await countGuilds(interaction.client);
+    const votes = await countVotes(interaction.client);
+
     const owner = ((await interaction.client.users.fetch("657057112593268756")) as User)?.tag;
     const tags = await Promise.all(
       contributors.map(c => interaction.client.users.fetch(c as `${bigint}`).then(m => m.tag))
     ).then(tags =>
       tags
         .map(tag => {
-          return `- ${tag}`;
+          return `» ${tag}`;
         })
         .join("\n")
     );
-    await interaction.reply({
-      ephemeral: true,
-      embeds: [
-        new StandardEmbed(interaction.member as GuildMember)
-          .addField(
-            "Guilds",
-            `\`\`\`${interaction.client.guilds.cache.size.toString()}\`\`\``,
-            true
-          )
-          .addField("Users", `\`\`\`${interaction.client.users.cache.size.toString()}\`\`\``, true)
-          .addField("Songs Searched", `\`\`\`${count.toString()}\`\`\``, true)
-          .addField("Profiles", `\`\`\`${profiles.toString()}\`\`\``, true)
-          .addField("Created by", `\`\`\`${owner}\`\`\``)
-          .addField("Contributions by", `\`\`\`${tags}\`\`\``),
-      ],
-    });
+    // await interaction.reply({
+    //   ephemeral: true,
+    //   embeds: [
+    //     new StandardEmbed(interaction.member as GuildMember)
+    //       .addField(
+    //         "Guilds",
+    //         `\`\`\`${interaction.client.guilds.cache.size.toString()}\`\`\``,
+    //         true
+    //       )
+    //       .addField("Users", `\`\`\`${interaction.client.users.cache.size.toString()}\`\`\``, true)
+    //       .addField("Songs Searched", `\`\`\`${count.toString()}\`\`\``, true)
+    //       .addField("Profiles", `\`\`\`${profiles.toString()}\`\`\``, true)
+    //       .addField("Created by", `\`\`\`${owner}\`\`\``)
+    //       .addField("Contributions by", `\`\`\`${tags}\`\`\``),
+    //   ],
+    // });
+
+    await interaction.editReply({
+      embeds: [new StandardEmbed(interaction.member as GuildMember)
+          .setAuthor((interaction.member as GuildMember).user.tag, (interaction.member as GuildMember).user.displayAvatarURL())
+          .setDescription("**Invite**: https://tunes.ninja/invite\n" +
+              "**Vote**: https://tunes.ninja/vote\n" +
+              "**GitHub**: https://tunes.ninja/github")
+          .addField("Discord Stats", `» \`${guilds}\` guilds\n» \`${profiles}\` active users\n`)
+          .addField("Bot Stats", `» \`${songs}\` songs searched\n» \`${playlists}\` playlists\n» \`${votes}\` votes\n» Up for \`${dayjs.duration(interaction.client!.uptime!).humanize()}\`\n`)
+          .addField("Developed by", `<@657057112593268756> (\`${owner}\`)`)
+          .addField("Contributions by", `${tags}`)
+
+      ]
+    })
   },
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import {Permer} from "permer";
+import { Permer } from "permer";
 
 /**
  * Whether or not the app is running in development mode
@@ -18,6 +18,7 @@ export const contributors = [
   "291050399509774340",
   "215143736114544640",
   "90339695967350784",
+  "140214425276776449",
 ];
 
 export const friends = [
@@ -27,4 +28,8 @@ export const friends = [
   "205039221050703872",
 ];
 
-export const permer = new Permer(["replySpotify", "replyAM", "replySoundcloud"]);
+export const permer = new Permer([
+  "replySpotify",
+  "replyAM",
+  "replySoundcloud",
+]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ scheduleJob("*/10 * * * *", async () => {
   });
 });
 
-scheduleJob("*/1 * * * *", async () => {
+scheduleJob("*/10 * * * *", async () => {
   const songs = await countSearches();
   const profiles = await countProfiles();
   const playlists = await countPlaylists();

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
   guildDelete,
   startupMessage,
 } from "./services/events/logging";
-import { countProfiles, countSearches } from "./services/util/count";
+import {countGuilds, countPlaylists, countProfiles, countSearches, countVotes} from "./services/util/count";
 import { BotRatelimited, UnknownSong } from "./structs/exceptions";
 import { scheduleJob } from "node-schedule";
 import { handleInteraction } from "./services/events/interaction";
@@ -181,15 +181,18 @@ scheduleJob("*/10 * * * *", async () => {
   });
 });
 
-scheduleJob("*/5 * * * *", async () => {
+scheduleJob("*/1 * * * *", async () => {
   const songs = await countSearches();
   const profiles = await countProfiles();
-  const guilds = await client.guilds.cache.size;
-  const votes = await new Topgg(client.user!.id).getVotes();
+  const playlists = await countPlaylists();
+  const guilds = await countGuilds(client);
+  const votes = await countVotes(client);
+
   await dd.send("bot.guilds", guilds);
   await dd.send("bot.songs", songs);
   await dd.send("bot.profiles", profiles);
-  await dd.send("bot.votes", votes.monthlyPoints);
+  await dd.send("bot.playlists", playlists);
+  await dd.send("bot.votes", votes);
 });
 
 prisma.$connect().then(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,8 @@ import { handleInteraction } from "./services/events/interaction";
 import AutoPoster from "topgg-autoposter";
 import { VotesServer } from "./services/util/server";
 import { Topgg } from "./services/api/topgg";
-import {DataDog} from "./services/api/datadog";
+import { DataDog } from "./services/api/datadog";
 import * as Sentry from "@sentry/node";
-
-
 
 const linkSchema = z.string().refine((x) => {
   return (
@@ -56,7 +54,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
 });
 
-const dd = new DataDog()
+const dd = new DataDog();
 
 client.on("ready", async () => {
   signale.info("Environment:", isDev ? "dev" : "prod");
@@ -126,7 +124,8 @@ client.on("messageCreate", async (message) => {
     matches.map(async (link) => {
       try {
         if (
-          link.includes("spotify.com/track") ||
+          (link.includes("spotify.com/track") &&
+            permer.test(guildSettings!.reply_to, "replySpotify")) ||
           (link.includes("spotify.com/album") &&
             permer.test(guildSettings!.reply_to, "replySpotify"))
         ) {
@@ -200,8 +199,6 @@ prisma.$connect().then(async () => {
   signale.info("Connected to Discord");
 });
 
-
-process
-    .on('uncaughtException', async err => {
-      Sentry.captureException(err)
-    });
+process.on("uncaughtException", async (err) => {
+  Sentry.captureException(err);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ new VotesServer(client).start();
 Sentry.init({
   dsn: process.env.SENTRY,
   tracesSampleRate: 1.0,
+  release: "tunes.ninja@" + process.env.npm_package_version,
 });
 
 const dd = new DataDog();

--- a/src/inhibitors/voted.ts
+++ b/src/inhibitors/voted.ts
@@ -1,13 +1,14 @@
-import {Topgg} from "../services/api/topgg";
-import {Inhibitor} from "../types/command";
+import { isDev } from "../constants";
+import { Topgg } from "../services/api/topgg";
+import { Inhibitor } from "../types/command";
 
-export const voted: Inhibitor = async interaction => {
+export const voted: Inhibitor = async (interaction) => {
   const hasVoted = await new Topgg(interaction.client.user!.id).hasVoted(
     interaction,
     interaction.user.id
   );
 
-  if (!hasVoted) {
+  if (!hasVoted && !isDev) {
     throw new Error(
       `Before using this feature please upvote us on Top.gg - it really helps us out! [Click here to vote!](https://tunes.ninja/vote)`
     );

--- a/src/services/api/datadog.ts
+++ b/src/services/api/datadog.ts
@@ -6,12 +6,12 @@ metrics.init({ apiKey: process.env.DD_API_KEY });
 export class DataDog {
   public async inc(key: string) {
     isDev
-      ? signale.log(`Metric sinkholed ${key}`)
+      ? signale.info(`Metric sinkholed: ${key}`)
       : await metrics.increment(key);
   }
   public async send(key: string, value: number) {
     isDev
-      ? signale.log(`Metric sinkholed ${key}:${value}`)
+      ? signale.info(`Metric sinkholed: ${key}, value ${value}`)
       : await metrics.gauge(key, value);
   }
 }

--- a/src/services/api/datadog.ts
+++ b/src/services/api/datadog.ts
@@ -1,11 +1,12 @@
 import metrics from "datadog-metrics";
 metrics.init({ apiKey: process.env.DD_API_KEY });
 
+// TODO: unsync these API calls
 export class DataDog {
   public async inc(key: string) {
-    await metrics.increment(key);
+    // await metrics.increment(key);
   }
   public async send(key: string, value: number) {
-    await metrics.gauge(key, value);
+    // await metrics.gauge(key, value);
   }
 }

--- a/src/services/api/datadog.ts
+++ b/src/services/api/datadog.ts
@@ -1,12 +1,17 @@
 import metrics from "datadog-metrics";
+import signale from "signale";
+import { isDev } from "../../constants";
 metrics.init({ apiKey: process.env.DD_API_KEY });
 
-// TODO: unsync these API calls
 export class DataDog {
   public async inc(key: string) {
-    // await metrics.increment(key);
+    isDev
+      ? signale.log(`Metric sinkholed ${key}`)
+      : await metrics.increment(key);
   }
   public async send(key: string, value: number) {
-    // await metrics.gauge(key, value);
+    isDev
+      ? signale.log(`Metric sinkholed ${key}:${value}`)
+      : await metrics.gauge(key, value);
   }
 }

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -108,10 +108,11 @@ export class JoshAPI {
     public static async playlist(
         server: string,
         channel: string,
-        user: string
+        user: string,
+        platform: string
     ): Promise<JoshLink> {
         const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}link/playlist/creation`,
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/link/playlist/creation`,
             {
                 method: "POST",
                 headers: {
@@ -119,7 +120,7 @@ export class JoshAPI {
                     Authorization: `${process.env.JOSH_AUTH}`,
                 },
                 body: JSON.stringify({
-                    platform: "spotify",
+                    playlistId: platform.toString(),
                     discordChannelID: channel.toString(),
                     discordServerID: server.toString(),
                     discordUserID: user.toString(),
@@ -161,41 +162,41 @@ export class JoshAPI {
         return body;
     }
 
-    /* eslint-disable  @typescript-eslint/no-explicit-any */
-    public static async add(
-        message: Message | CommandInteraction,
-        url: string
-    ): Promise<any> {
-        let author;
-        if (message instanceof Message) {
-            author = message.author;
-        }
-        if (message instanceof CommandInteraction) {
-            if (!message.deferred) {
-                await message.deferReply();
-            }
-            author = message.member;
-        }
-
-        await fetch(`${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}add/new/song/premium`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `${process.env.JOSH_AUTH}`,
-            },
-            body: JSON.stringify({
-                platform: "spotify",
-                discordChannelID: message.channel!.id.toString(),
-                discordServerID: message.guild!.id.toString(),
-                discordUserID: (author as User).id.toString(),
-                url,
-            }),
-        });
-
-        if (message instanceof Message) {
-            await message.react("🎶");
-        }
-    }
+    // /* eslint-disable  @typescript-eslint/no-explicit-any */
+    // public static async add(
+    //     message: Message | CommandInteraction,
+    //     url: string
+    // ): Promise<any> {
+    //     let author;
+    //     if (message instanceof Message) {
+    //         author = message.author;
+    //     }
+    //     if (message instanceof CommandInteraction) {
+    //         if (!message.deferred) {
+    //             await message.deferReply();
+    //         }
+    //         author = message.member;
+    //     }
+    //
+    //     await fetch(`${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}add/new/song/premium`, {
+    //         method: "POST",
+    //         headers: {
+    //             "Content-Type": "application/json",
+    //             Authorization: `${process.env.JOSH_AUTH}`,
+    //         },
+    //         body: JSON.stringify({
+    //             platform: "spotify",
+    //             discordChannelID: message.channel!.id.toString(),
+    //             discordServerID: message.guild!.id.toString(),
+    //             discordUserID: (author as User).id.toString(),
+    //             url,
+    //         }),
+    //     });
+    //
+    //     if (message instanceof Message) {
+    //         await message.react("🎶");
+    //     }
+    // }
 
     public static async getPlaylists(user: string, platform: string): Promise<any> {
         console.log(platform)
@@ -220,12 +221,24 @@ export class JoshAPI {
         return body;
     }
 
-    public static async addPersonalPlaylist(
+    public static async add(
         user: string,
         playlist: string,
         song: string,
         platform: string
     ): Promise<any> {
+
+            // let author;
+            // if (message instanceof Message) {
+            //     author = message.author;
+            // }
+            // if (message instanceof CommandInteraction) {
+            //     if (!message.deferred) {
+            //         await message.deferReply();
+            //     }
+            //     author = message.member;
+            // }
+
         const response = await fetch(
             `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/playlist/add/song`,
             {
@@ -247,5 +260,9 @@ export class JoshAPI {
             throw new Error(body.detail);
         }
         return body;
+    }
+
+    public static async sync(channel: string) {
+
     }
 }

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -130,7 +130,7 @@ export class JoshAPI {
     const response = await fetch(
       `${
         isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
-      }linked/playlists/channels/${channel}`,
+      }linked/playlists/channels/${channel}?getPlaylistName=true`,
       {
         method: "GET",
         headers: {

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -1,265 +1,307 @@
-import {CommandInteraction, Message, User} from "discord.js";
+/*
+To anyone who may view this file before I get the chance to rewrite it,
+this is an extremely disgusting way to handle the interactions
+between the tunes.ninja API and the front end. It's also not typed
+at all and just returns Promise<any>, which entirely defeats the point
+of TypeScript! The functions are also super poorly named but it Works™
+
+Please don't be like me. I'll eventually rewrite the class with an API
+handler and whatever else but this is what I will make do with for now.
+
+Thanks for not roasting me <3 (and if you see this tweet me @laf0nd!)
+
+Love,
+Jack, 8/22/21 at 10:22pm
+ */
+
+import { CommandInteraction, Message, User } from "discord.js";
 import fetch from "node-fetch";
-import {isDev} from "../../constants";
-import {JoshLink} from "../../types/josh";
-import {prisma} from "../prisma";
+import { isDev } from "../../constants";
+import { JoshLink } from "../../types/josh";
+import { prisma } from "../prisma";
 
 export class JoshAPI {
-    public static async link(
-        server: string,
-        channel: string,
-        user: string,
-        platform: string
-    ): Promise<string> {
-        const response = await fetch(
-            `${
-                isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
-            }login/user/${platform}`,
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `${process.env.JOSH_AUTH}`,
-                },
-                body: JSON.stringify({
-                    platform: platform.toString(),
-                    discordUserID: user.toString(),
-                }),
-            }
-        );
+  public static async linkUser(
+    server: string,
+    channel: string,
+    user: string,
+    platform: string
+  ): Promise<string> {
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }login/user/${platform}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          platform: platform.toString(),
+          discordUserID: user.toString(),
+        }),
+      }
+    );
 
-        console.log(response)
+    console.log(response);
 
-        const body = await response.json();
-        if (response.status !== 200) {
-            throw new Error(body.detail.reason);
-        }
-        return body.url;
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error(body.detail.reason);
+    }
+    return body.url;
+  }
+
+  public static async getUser(user: string): Promise<any> {
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }linked/services/user/${user}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+      }
+    );
+
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error(body.detail.reason);
+    }
+    return body;
+  }
+
+  public static async unlinkUser(
+    user: string,
+    platform: string
+  ): Promise<boolean> {
+    const response = await fetch(
+      `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}unlink`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          platform: platform.toString(),
+          discordUserID: user.toString(),
+        }),
+      }
+    );
+
+    const body = await response.json();
+
+    if (response.status !== 200) {
+      throw new Error(body.detail.reason);
+    }
+    return true;
+  }
+
+  public static async playOnSpotify(
+    user: string,
+    song: string
+  ): Promise<string> {
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }spotify/user/${user}/action/play/song`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          spotifyTrackID: song.toString(),
+        }),
+      }
+    );
+
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error(body.detail.reason);
+    }
+    return body;
+  }
+
+  public static async getLinkedPlaylists(channel: string): Promise<any> {
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }linked/playlists/channels/${channel}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+      }
+    );
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error(body.detail.reason);
+    }
+    return body;
+  }
+
+  // TODO: redo creation playlist API route
+  public static async createPlaylist(
+    user: User,
+    platform: string
+  ): Promise<JoshLink> {
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }${platform}/create/playlist`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          playlistName: `${user.username}'s synced playlist`,
+          discordUserId: user.id.toString(),
+        }),
+      }
+    );
+
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error(body.detail.reason);
+    }
+    return body;
+  }
+
+  public static async addToPlaylist(
+    message: Message | CommandInteraction,
+    platform: string,
+    playlistID: string,
+    trackID: string
+  ): Promise<any> {
+    let author;
+    if (message instanceof Message) {
+      author = message.author;
+    } else if (message instanceof CommandInteraction) {
+      if (!message.deferred) {
+        await message.deferReply();
+      }
+      author = message.member;
     }
 
-    public static async user(user: string): Promise<any> {
-        const response = await fetch(
-            `${
-                isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
-            }linked/services/user/${user}`,
-            {
-                method: "GET",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `${process.env.JOSH_AUTH}`,
-                },
-            }
-        );
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }/${platform}/playlist/add/song`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          discordUserID: (author as User).id.toString(),
+          playlistID,
+          trackID,
+        }),
+      }
+    );
+  }
 
-        const body = await response.json();
-        if (response.status !== 200) {
-            throw new Error(body.detail.reason);
-        }
-        return body;
+  public static async getUserPlaylists(
+    user: string,
+    platform: string
+  ): Promise<any> {
+    console.log(platform);
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }${platform}/users/playlists/${user}?fresh=true`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+      }
+    );
+
+    const body = await response.json();
+
+    console.log(body);
+
+    if (response.status !== 200) {
+      throw new Error(body.detail.reason);
     }
+    return body;
+  }
 
-    public static async unlink(user: string, platform: string): Promise<boolean> {
-        const response = await fetch(`${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}unlink`, {
-            method: "DELETE",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `${process.env.JOSH_AUTH}`,
-            },
-            body: JSON.stringify({
-                platform: platform.toString(),
-                discordUserID: user.toString(),
-            }),
-        });
+  public static async addSongToPlaylist(
+    user: string,
+    playlist: string,
+    song: string,
+    platform: string
+  ): Promise<any> {
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }${platform}/playlist/add/song`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          playlistID: playlist.toString(),
+          discordUserID: user.toString(),
+          trackID: song.toString(),
+        }),
+      }
+    );
 
-        const body = await response.json();
-
-        if (response.status !== 200) {
-            console.log(body);
-            throw new Error(body.detail.reason);
-        }
-        return true;
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error(body.detail);
     }
+    return body;
+  }
 
-    public static async play(user: string, song: string): Promise<string> {
-        const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}spotify/user/${user}/action/play/song`,
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `${process.env.JOSH_AUTH}`,
-                },
-                body: JSON.stringify({
-                    spotifyTrackID: song.toString(),
-                }),
-            }
-        );
+  public static async syncPlaylist(
+    server: string,
+    channel: string,
+    user: string,
+    platform: string,
+    playlistID: string
+  ): Promise<any> {
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }${platform}/link/playlist/user`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          playlistID,
+          discordUserID: user.toString(),
+          discordChannelID: channel.toString(),
+          discordServerID: server.toString(),
+        }),
+      }
+    );
 
-        const body = await response.json();
-        if (response.status !== 200) {
-            throw new Error(body.detail.reason);
-        }
-        return body;
+    console.log(response);
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error(body.detail);
     }
-
-    public static async playlist(
-        server: string,
-        channel: string,
-        user: string,
-        platform: string
-    ): Promise<JoshLink> {
-        const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/link/playlist/creation`,
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `${process.env.JOSH_AUTH}`,
-                },
-                body: JSON.stringify({
-                    playlistId: platform.toString(),
-                    discordChannelID: channel.toString(),
-                    discordServerID: server.toString(),
-                    discordUserID: user.toString(),
-                }),
-            }
-        );
-
-        const body = await response.json();
-        if (response.status !== 200) {
-            throw new Error(body.detail.reason);
-        }
-        return body;
-    }
-
-    /* eslint-disable  @typescript-eslint/no-explicit-any */
-    public static async delete(channel: string): Promise<any> {
-        const response = await fetch(`${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}unlink/playlist`, {
-            method: "DELETE",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `${process.env.JOSH_AUTH}`,
-            },
-            body: JSON.stringify({
-                platform: "spotify",
-                discordChannelID: channel.toString(),
-            }),
-        });
-
-        await prisma.joshChannel.delete({
-            where: {
-                id: channel.toString(),
-            },
-        });
-
-        const body = await response.json();
-        if (response.status !== 200) {
-            throw new Error(body.detail.reason);
-        }
-        return body;
-    }
-
-    // /* eslint-disable  @typescript-eslint/no-explicit-any */
-    // public static async add(
-    //     message: Message | CommandInteraction,
-    //     url: string
-    // ): Promise<any> {
-    //     let author;
-    //     if (message instanceof Message) {
-    //         author = message.author;
-    //     }
-    //     if (message instanceof CommandInteraction) {
-    //         if (!message.deferred) {
-    //             await message.deferReply();
-    //         }
-    //         author = message.member;
-    //     }
-    //
-    //     await fetch(`${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}add/new/song/premium`, {
-    //         method: "POST",
-    //         headers: {
-    //             "Content-Type": "application/json",
-    //             Authorization: `${process.env.JOSH_AUTH}`,
-    //         },
-    //         body: JSON.stringify({
-    //             platform: "spotify",
-    //             discordChannelID: message.channel!.id.toString(),
-    //             discordServerID: message.guild!.id.toString(),
-    //             discordUserID: (author as User).id.toString(),
-    //             url,
-    //         }),
-    //     });
-    //
-    //     if (message instanceof Message) {
-    //         await message.react("🎶");
-    //     }
-    // }
-
-    public static async getPlaylists(user: string, platform: string): Promise<any> {
-        console.log(platform)
-        const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/users/playlists/${user}?fresh=true`,
-            {
-                method: "GET",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `${process.env.JOSH_AUTH}`,
-                }
-            }
-        );
-
-        const body = await response.json();
-
-        console.log(body)
-
-        if (response.status !== 200) {
-            throw new Error(body.detail.reason);
-        }
-        return body;
-    }
-
-    public static async add(
-        user: string,
-        playlist: string,
-        song: string,
-        platform: string
-    ): Promise<any> {
-
-            // let author;
-            // if (message instanceof Message) {
-            //     author = message.author;
-            // }
-            // if (message instanceof CommandInteraction) {
-            //     if (!message.deferred) {
-            //         await message.deferReply();
-            //     }
-            //     author = message.member;
-            // }
-
-        const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/playlist/add/song`,
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `${process.env.JOSH_AUTH}`,
-                },
-                body: JSON.stringify({
-                    playlistID: playlist.toString(),
-                    discordUserID: user.toString(),
-                    trackID: song.toString()
-                })
-            }
-        );
-
-        const body = await response.json();
-        if (response.status !== 200) {
-            throw new Error(body.detail);
-        }
-        return body;
-    }
-
-    public static async sync(channel: string) {
-
-    }
+    return body;
+  }
 }

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -175,41 +175,6 @@ export class JoshAPI {
     return body;
   }
 
-  public static async addToPlaylist(
-    message: Message | CommandInteraction,
-    platform: string,
-    playlistID: string,
-    trackID: string
-  ): Promise<any> {
-    let author;
-    if (message instanceof Message) {
-      author = message.author;
-    } else if (message instanceof CommandInteraction) {
-      if (!message.deferred) {
-        await message.deferReply();
-      }
-      author = message.member;
-    }
-
-    const response = await fetch(
-      `${
-        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
-      }/${platform}/playlist/add/song`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `${process.env.JOSH_AUTH}`,
-        },
-        body: JSON.stringify({
-          discordUserID: (author as User).id.toString(),
-          playlistID,
-          trackID,
-        }),
-      }
-    );
-  }
-
   public static async getUserPlaylists(
     user: string,
     platform: string
@@ -241,6 +206,7 @@ export class JoshAPI {
     song: string,
     platform: string
   ): Promise<any> {
+    console.log(user, playlist, song, platform);
     const response = await fetch(
       `${
         isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -30,10 +30,11 @@ export class JoshAPI {
             }
         );
 
+        console.log(response)
+
         const body = await response.json();
         if (response.status !== 200) {
-            if (!body.detail) throw new Error(body.reason);
-            if (body.detail) throw new Error(body.detail);
+            throw new Error(body.detail.reason);
         }
         return body.url;
     }
@@ -54,8 +55,7 @@ export class JoshAPI {
 
         const body = await response.json();
         if (response.status !== 200) {
-            if (!body.detail) throw new Error(body.reason);
-            if (body.detail) throw new Error(body.detail.reason);
+            throw new Error(body.detail.reason);
         }
         return body;
     }
@@ -77,8 +77,7 @@ export class JoshAPI {
 
         if (response.status !== 200) {
             console.log(body);
-            if (!body.detail) throw new Error(body.reason);
-            if (body.detail) throw new Error(body.detail);
+            throw new Error(body.detail.reason);
         }
         return true;
     }
@@ -214,7 +213,7 @@ export class JoshAPI {
         console.log(body)
 
         if (response.status !== 200) {
-            throw new Error(body.detail);
+            throw new Error(body.detail.reason);
         }
         return body;
     }

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -1,239 +1,241 @@
-import { CommandInteraction, Message, User } from "discord.js";
+import {CommandInteraction, Message, User} from "discord.js";
 import fetch from "node-fetch";
-import { isDev } from "../../constants";
-import { JoshLink } from "../../types/josh";
-import { prisma } from "../prisma";
+import {isDev} from "../../constants";
+import {JoshLink} from "../../types/josh";
+import {prisma} from "../prisma";
 
 export class JoshAPI {
-  public static async link(
-    server: string,
-    channel: string,
-    user: string,
-    platform: string
-  ): Promise<string> {
-    const response = await fetch(
-      `${
-        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
-      }login/user/${platform}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `${process.env.JOSH_AUTH}`,
-        },
-        body: JSON.stringify({
-          platform: platform.toString(),
-          discordChannelID: channel.toString(),
-          discordServerID: server.toString(),
-          discordUserID: user.toString(),
-        }),
-      }
-    );
+    public static async link(
+        server: string,
+        channel: string,
+        user: string,
+        platform: string
+    ): Promise<string> {
+        const response = await fetch(
+            `${
+                isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+            }login/user/${platform}`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${process.env.JOSH_AUTH}`,
+                },
+                body: JSON.stringify({
+                    platform: platform.toString(),
+                    discordChannelID: channel.toString(),
+                    discordServerID: server.toString(),
+                    discordUserID: user.toString(),
+                }),
+            }
+        );
 
-    const body = await response.json();
-    if (response.status !== 200) {
-      if (!body.detail) throw new Error(body.reason);
-      if (body.detail) throw new Error(body.detail.reason);
-    }
-    return body.url;
-  }
-
-  public static async user(user: string): Promise<any> {
-    const response = await fetch(
-      `${
-        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
-      }linked/services/user/${user}`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `${process.env.JOSH_AUTH}`,
-        },
-      }
-    );
-
-    const body = await response.json();
-    if (response.status !== 200) {
-      if (!body.detail) throw new Error(body.reason);
-      if (body.detail) throw new Error(body.detail.reason);
-    }
-    return body;
-  }
-
-  public static async unlink(user: string, platform: string): Promise<boolean> {
-    const response = await fetch(`${process.env.JOSH_BASE}unlink/${platform}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `${process.env.JOSH_AUTH}`,
-      },
-      body: JSON.stringify({
-        discordUserID: user.toString(),
-      }),
-    });
-
-    const body = await response.json();
-
-    if (response.status !== 200) {
-      if (!body.detail) throw new Error(body.reason);
-      if (body.detail) throw new Error(body.detail.reason);
-    }
-    return true;
-  }
-
-  public static async play(user: string, song: string): Promise<string> {
-    const response = await fetch(
-      `${process.env.JOSH_BASE}spotify/user/${user}/action/play/song`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `${process.env.JOSH_AUTH}`,
-        },
-        body: JSON.stringify({
-          spotifyTrackID: song.toString(),
-        }),
-      }
-    );
-
-    const body = await response.json();
-    if (response.status !== 200) {
-      throw new Error(body.detail.reason);
-    }
-    return body;
-  }
-
-  public static async playlist(
-    server: string,
-    channel: string,
-    user: string
-  ): Promise<JoshLink> {
-    const response = await fetch(
-      `${process.env.JOSH_BASE}link/playlist/creation`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `${process.env.JOSH_AUTH}`,
-        },
-        body: JSON.stringify({
-          platform: "spotify",
-          discordChannelID: channel.toString(),
-          discordServerID: server.toString(),
-          discordUserID: user.toString(),
-        }),
-      }
-    );
-
-    const body = await response.json();
-    if (response.status !== 200) {
-      throw new Error(body.detail.reason);
-    }
-    return body;
-  }
-
-  /* eslint-disable  @typescript-eslint/no-explicit-any */
-  public static async delete(channel: string): Promise<any> {
-    const response = await fetch(`${process.env.JOSH_BASE}unlink/playlist`, {
-      method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `${process.env.JOSH_AUTH}`,
-      },
-      body: JSON.stringify({
-        platform: "spotify",
-        discordChannelID: channel.toString(),
-      }),
-    });
-
-    await prisma.joshChannel.delete({
-      where: {
-        id: channel.toString(),
-      },
-    });
-
-    const body = await response.json();
-    if (response.status !== 200) {
-      throw new Error(body.detail.reason);
-    }
-    return body;
-  }
-
-  /* eslint-disable  @typescript-eslint/no-explicit-any */
-  public static async add(
-    message: Message | CommandInteraction,
-    url: string
-  ): Promise<any> {
-    let author;
-    if (message instanceof Message) {
-      author = message.author;
-    }
-    if (message instanceof CommandInteraction) {
-      if (!message.deferred) {
-        await message.deferReply();
-      }
-      author = message.member;
+        const body = await response.json();
+        if (response.status !== 200) {
+            if (!body.detail) throw new Error(body.reason);
+            if (body.detail) throw new Error(body.detail.reason);
+        }
+        return body.url;
     }
 
-    await fetch(`${process.env.JOSH_BASE}add/new/song/premium`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `${process.env.JOSH_AUTH}`,
-      },
-      body: JSON.stringify({
-        platform: "spotify",
-        discordChannelID: message.channel!.id.toString(),
-        discordServerID: message.guild!.id.toString(),
-        discordUserID: (author as User).id.toString(),
-        url,
-      }),
-    });
+    public static async user(user: string): Promise<any> {
+        const response = await fetch(
+            `${
+                isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+            }linked/services/user/${user}`,
+            {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${process.env.JOSH_AUTH}`,
+                },
+            }
+        );
 
-    if (message instanceof Message) {
-      await message.react("🎶");
+        const body = await response.json();
+        if (response.status !== 200) {
+            if (!body.detail) throw new Error(body.reason);
+            if (body.detail) throw new Error(body.detail.reason);
+        }
+        return body;
     }
-  }
 
-  public static async getPlaylists(user: string): Promise<any> {
-    const response = await fetch(
-      `${process.env.JOSH_BASE}playlists/${user}?fresh=true`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `${process.env.JOSH_AUTH}`,
-        },
-      }
-    );
+    public static async unlink(user: string, platform: string): Promise<boolean> {
+        const response = await fetch(`${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}unlink`, {
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `${process.env.JOSH_AUTH}`,
+            },
+            body: JSON.stringify({
+                platform: platform.toString(),
+                discordUserID: user.toString(),
+            }),
+        });
 
-    const body = await response.json();
-    if (response.status !== 200) {
-      throw new Error(body.detail.reason);
+        const body = await response.json();
+
+        if (response.status !== 200) {
+            console.log(body);
+            if (!body.detail) throw new Error(body.reason);
+            if (body.detail) throw new Error(body.detail);
+        }
+        return true;
     }
-    return body;
-  }
 
-  public static async addPersonalPlaylist(
-    user: string,
-    playlist: string,
-    song: string
-  ): Promise<any> {
-    const response = await fetch(
-      `${process.env.JOSH_BASE}user/${user}/playlist/${playlist}/add?song_id=${song}`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `${process.env.JOSH_AUTH}`,
-        },
-      }
-    );
+    public static async play(user: string, song: string): Promise<string> {
+        const response = await fetch(
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}spotify/user/${user}/action/play/song`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${process.env.JOSH_AUTH}`,
+                },
+                body: JSON.stringify({
+                    spotifyTrackID: song.toString(),
+                }),
+            }
+        );
 
-    const body = await response.json();
-    if (response.status !== 200) {
-      throw new Error(body.detail.reason);
+        const body = await response.json();
+        if (response.status !== 200) {
+            throw new Error(body.detail.reason);
+        }
+        return body;
     }
-    return body;
-  }
+
+    public static async playlist(
+        server: string,
+        channel: string,
+        user: string
+    ): Promise<JoshLink> {
+        const response = await fetch(
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}link/playlist/creation`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${process.env.JOSH_AUTH}`,
+                },
+                body: JSON.stringify({
+                    platform: "spotify",
+                    discordChannelID: channel.toString(),
+                    discordServerID: server.toString(),
+                    discordUserID: user.toString(),
+                }),
+            }
+        );
+
+        const body = await response.json();
+        if (response.status !== 200) {
+            throw new Error(body.detail.reason);
+        }
+        return body;
+    }
+
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    public static async delete(channel: string): Promise<any> {
+        const response = await fetch(`${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}unlink/playlist`, {
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `${process.env.JOSH_AUTH}`,
+            },
+            body: JSON.stringify({
+                platform: "spotify",
+                discordChannelID: channel.toString(),
+            }),
+        });
+
+        await prisma.joshChannel.delete({
+            where: {
+                id: channel.toString(),
+            },
+        });
+
+        const body = await response.json();
+        if (response.status !== 200) {
+            throw new Error(body.detail.reason);
+        }
+        return body;
+    }
+
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    public static async add(
+        message: Message | CommandInteraction,
+        url: string
+    ): Promise<any> {
+        let author;
+        if (message instanceof Message) {
+            author = message.author;
+        }
+        if (message instanceof CommandInteraction) {
+            if (!message.deferred) {
+                await message.deferReply();
+            }
+            author = message.member;
+        }
+
+        await fetch(`${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}add/new/song/premium`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `${process.env.JOSH_AUTH}`,
+            },
+            body: JSON.stringify({
+                platform: "spotify",
+                discordChannelID: message.channel!.id.toString(),
+                discordServerID: message.guild!.id.toString(),
+                discordUserID: (author as User).id.toString(),
+                url,
+            }),
+        });
+
+        if (message instanceof Message) {
+            await message.react("🎶");
+        }
+    }
+
+    public static async getPlaylists(user: string): Promise<any> {
+        const response = await fetch(
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}playlists/${user}?fresh=true`,
+            {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${process.env.JOSH_AUTH}`,
+                },
+            }
+        );
+
+        const body = await response.json();
+        if (response.status !== 200) {
+            throw new Error(body.detail.reason);
+        }
+        return body;
+    }
+
+    public static async addPersonalPlaylist(
+        user: string,
+        playlist: string,
+        song: string
+    ): Promise<any> {
+        const response = await fetch(
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}user/${user}/playlist/${playlist}/add?song_id=${song}`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${process.env.JOSH_AUTH}`,
+                },
+            }
+        );
+
+        const body = await response.json();
+        if (response.status !== 200) {
+            throw new Error(body.detail.reason);
+        }
+        return body;
+    }
 }

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -7,21 +7,25 @@ export class JoshAPI {
   public static async link(
     server: string,
     channel: string,
-    user: string
+    user: string,
+    platform: string
   ): Promise<string> {
-    const response = await fetch(`${process.env.JOSH_BASE}login/user/spotify`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `${process.env.JOSH_AUTH}`,
-      },
-      body: JSON.stringify({
-        platform: "spotify",
-        discordChannelID: channel.toString(),
-        discordServerID: server.toString(),
-        discordUserID: user.toString(),
-      }),
-    });
+    const response = await fetch(
+      `${process.env.JOSH_BASE}login/user/${platform}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          platform: platform.toString(),
+          discordChannelID: channel.toString(),
+          discordServerID: server.toString(),
+          discordUserID: user.toString(),
+        }),
+      }
+    );
 
     const body = await response.json();
     if (response.status !== 200) {
@@ -31,9 +35,28 @@ export class JoshAPI {
     return body.url;
   }
 
-  // TODO: fix unlink
-  public static async unlink(user: string): Promise<boolean> {
-    const response = await fetch(`${process.env.JOSH_BASE}unlink/spotify`, {
+  public static async user(user: string): Promise<string> {
+    const response = await fetch(
+      `${process.env.JOSH_BASE}/linked/user/${user}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+      }
+    );
+
+    const body = await response.json();
+    if (response.status !== 200) {
+      if (!body.detail) throw new Error(body.reason);
+      if (body.detail) throw new Error(body.detail.reason);
+    }
+    return body;
+  }
+
+  public static async unlink(user: string, platform: string): Promise<boolean> {
+    const response = await fetch(`${process.env.JOSH_BASE}unlink/${platform}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -106,7 +106,7 @@ export class JoshAPI {
     const response = await fetch(
       `${
         isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
-      }spotify/user/${user}/action/play/song`,
+      }spotify/play/song/now`,
       {
         method: "POST",
         headers: {
@@ -114,14 +114,43 @@ export class JoshAPI {
           Authorization: `${process.env.JOSH_AUTH}`,
         },
         body: JSON.stringify({
-          spotifyTrackID: song.toString(),
+          trackID: song.toString(),
+          discordUserID: user.toString()
         }),
       }
     );
 
     const body = await response.json();
     if (response.status !== 200) {
-      throw new Error(body.detail.reason);
+      throw new Error(body.reason);
+    }
+    return body;
+  }
+
+  public static async queueOnSpotify(
+      user: string,
+      song: string
+  ): Promise<string> {
+    const response = await fetch(
+        `${
+            isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+        }spotify/play/song/queue`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `${process.env.JOSH_AUTH}`,
+          },
+          body: JSON.stringify({
+            trackID: song.toString(),
+            discordUserID: user.toString()
+          }),
+        }
+    );
+
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error(body.reason);
     }
     return body;
   }

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -44,8 +44,6 @@ export class JoshAPI {
       }
     );
 
-    console.log(response);
-
     const body = await response.json();
     if (response.status !== 200) {
       throw new Error(body.detail.reason);
@@ -216,7 +214,6 @@ export class JoshAPI {
     user: string,
     platform: string
   ): Promise<any> {
-    console.log(platform);
     const response = await fetch(
       `${
         isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
@@ -231,8 +228,6 @@ export class JoshAPI {
     );
 
     const body = await response.json();
-
-    console.log(body);
 
     if (response.status !== 200) {
       throw new Error(body.detail.reason);
@@ -297,10 +292,36 @@ export class JoshAPI {
       }
     );
 
-    console.log(response);
     const body = await response.json();
     if (response.status !== 200) {
       throw new Error(body.detail);
+    }
+    return body;
+  }
+
+  public static async unsyncPlaylist(
+    channel: string,
+    platform: string
+  ): Promise<any> {
+    const response = await fetch(
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }${platform}/unlink/playlist`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${process.env.JOSH_AUTH}`,
+        },
+        body: JSON.stringify({
+          discordChannelID: channel.toString(),
+        }),
+      }
+    );
+
+    const body = await response.json();
+    if (response.status !== 200) {
+      throw new Error("No playlist is synced with this channel.");
     }
     return body;
   }

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -33,7 +33,7 @@ export class JoshAPI {
         const body = await response.json();
         if (response.status !== 200) {
             if (!body.detail) throw new Error(body.reason);
-            if (body.detail) throw new Error(body.detail.reason);
+            if (body.detail) throw new Error(body.detail);
         }
         return body.url;
     }
@@ -197,9 +197,9 @@ export class JoshAPI {
         }
     }
 
-    public static async getPlaylists(user: string): Promise<any> {
+    public static async getPlaylists(user: string, platform: string): Promise<any> {
         const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}playlists/${user}?fresh=true`,
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/playlists/${user}?fresh=true`,
             {
                 method: "GET",
                 headers: {
@@ -210,8 +210,11 @@ export class JoshAPI {
         );
 
         const body = await response.json();
+
+        console.log(body)
+
         if (response.status !== 200) {
-            throw new Error(body.detail.reason);
+            throw new Error(body.detail);
         }
         return body;
     }
@@ -219,16 +222,22 @@ export class JoshAPI {
     public static async addPersonalPlaylist(
         user: string,
         playlist: string,
-        song: string
+        song: string,
+        platform: string
     ): Promise<any> {
         const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}user/${user}/playlist/${playlist}/add?song_id=${song}`,
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/playlist/add`,
             {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
                     Authorization: `${process.env.JOSH_AUTH}`,
                 },
+                body: JSON.stringify({
+                    playlistID: playlist.toString(),
+                    discordUserID: user.toString(),
+                    trackID: song.toString()
+                })
             }
         );
 

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -121,7 +121,9 @@ export class JoshAPI {
     );
 
     const body = await response.json();
+    console.log(body)
     if (response.status !== 200) {
+      if (body.code === "1993") throw new Error("Your Spotify credentials are missing! Do `/api link` to set this up.")
       throw new Error(body.reason);
     }
     return body;
@@ -150,6 +152,7 @@ export class JoshAPI {
 
     const body = await response.json();
     if (response.status !== 200) {
+      if (body.code === "1993") throw new Error("Your Spotify credentials are missing! Do `/api link` to set this up.")
       throw new Error(body.reason);
     }
     return body;

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -23,12 +23,12 @@ export class JoshAPI {
                 },
                 body: JSON.stringify({
                     platform: platform.toString(),
-                    discordChannelID: channel.toString(),
-                    discordServerID: server.toString(),
                     discordUserID: user.toString(),
                 }),
             }
         );
+
+        console.log(response)
 
         const body = await response.json();
         if (response.status !== 200) {
@@ -198,14 +198,15 @@ export class JoshAPI {
     }
 
     public static async getPlaylists(user: string, platform: string): Promise<any> {
+        console.log(platform)
         const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/playlists/${user}?fresh=true`,
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/users/playlists/${user}?fresh=true`,
             {
                 method: "GET",
                 headers: {
                     "Content-Type": "application/json",
                     Authorization: `${process.env.JOSH_AUTH}`,
-                },
+                }
             }
         );
 
@@ -226,7 +227,7 @@ export class JoshAPI {
         platform: string
     ): Promise<any> {
         const response = await fetch(
-            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/playlist/add`,
+            `${isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE}${platform}/playlist/add/song`,
             {
                 method: "POST",
                 headers: {
@@ -243,7 +244,7 @@ export class JoshAPI {
 
         const body = await response.json();
         if (response.status !== 200) {
-            throw new Error(body.detail.reason);
+            throw new Error(body.detail);
         }
         return body;
     }

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -1,5 +1,6 @@
 import { CommandInteraction, Message, User } from "discord.js";
 import fetch from "node-fetch";
+import { isDev } from "../../constants";
 import { JoshLink } from "../../types/josh";
 import { prisma } from "../prisma";
 
@@ -11,7 +12,9 @@ export class JoshAPI {
     platform: string
   ): Promise<string> {
     const response = await fetch(
-      `${process.env.JOSH_BASE}login/user/${platform}`,
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }login/user/${platform}`,
       {
         method: "POST",
         headers: {
@@ -37,7 +40,9 @@ export class JoshAPI {
 
   public static async user(user: string): Promise<string> {
     const response = await fetch(
-      `${process.env.JOSH_BASE}/linked/user/${user}`,
+      `${
+        isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
+      }/linked/user/${user}`,
       {
         method: "POST",
         headers: {

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -146,7 +146,6 @@ export class JoshAPI {
     return body;
   }
 
-  // TODO: redo creation playlist API route
   public static async createPlaylist(
     user: User,
     platform: string

--- a/src/services/api/josh.ts
+++ b/src/services/api/josh.ts
@@ -38,13 +38,13 @@ export class JoshAPI {
     return body.url;
   }
 
-  public static async user(user: string): Promise<string> {
+  public static async user(user: string): Promise<any> {
     const response = await fetch(
       `${
         isDev ? process.env.JOSH_DEV_BASE : process.env.JOSH_BASE
-      }/linked/user/${user}`,
+      }linked/services/user/${user}`,
       {
-        method: "POST",
+        method: "GET",
         headers: {
           "Content-Type": "application/json",
           Authorization: `${process.env.JOSH_AUTH}`,

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -177,6 +177,7 @@ export async function handleSelectInteraction(
 export async function handleButtonInteraction(
   interaction: ButtonInteraction
 ): Promise<void> {
+  if (interaction.customId.includes("playlistSelect")) return;
   try {
     await interaction.deferUpdate();
     dd.inc(`interactions.ButtonInteraction.run`);

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -142,11 +142,13 @@ export async function handleSelectInteraction(
 ): Promise<void> {
   await interaction.deferUpdate();
   await dd.inc(`interactions.SelectMenuInteraction.run`);
-  const userId = interaction.customId.split("select_")[1];
+  const userId = interaction.customId.split("select_")[1].split("_")[0];
+  const platform = interaction.customId.split("select_")[1].split("_")[1];
   const playlistId = interaction.values[0].split("_")[1];
-  const songId = interaction.values[0].split("_")[2];
-  const platform = "apple-music"
-  const request = await JoshAPI.addPersonalPlaylist(userId, playlistId, songId, platform);
+  // console.log(interaction.values[0])
+  const songId = interaction.values[0].split("_")[2].split("&")[0]
+  console.log(userId, playlistId, songId, platform)
+  const request = await JoshAPI.addPersonalPlaylist(userId, playlistId, songId, platforms[platform]);
   if (request.status === true) {
     await interaction.editReply({
       embeds: [

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -1,4 +1,5 @@
 import {
+  ButtonInteraction,
   CommandInteraction,
   ContextMenuInteraction,
   DiscordAPIError,
@@ -26,6 +27,7 @@ export async function handleInteraction(
     return await handleMessageInteraction(interaction);
   if (interaction.isSelectMenu())
     return await handleSelectInteraction(interaction);
+  if (interaction.isButton()) return await handleButtonInteraction(interaction);
 }
 
 export async function handleContextInteraction(
@@ -154,4 +156,20 @@ export async function handleSelectInteraction(
     });
   }
   await dd.inc(`interactions.SelectMenuInteraction.run`);
+}
+
+export async function handleButtonInteraction(
+  interaction: ButtonInteraction
+): Promise<void> {
+  await interaction.deferUpdate();
+  const platform = interaction.customId.split("button_")[1];
+  const request = await JoshAPI.link(
+    interaction.guild!.id,
+    interaction.channel!.id,
+    interaction.user!.id,
+    platform
+  );
+
+  console.log(request);
+  await dd.inc(`interactions.ButtonInteraction.run`);
 }

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -171,8 +171,6 @@ export async function handleButtonInteraction(
     platform
   );
 
-  console.log(request);
-
   await interaction.editReply({
     components: [],
     content: `[Click here to link your ${platform

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -94,7 +94,7 @@ export async function handleMessageInteraction(
   interaction: CommandInteraction
 ): Promise<void> {
     try {
-        dd.inc(`interactions.CommandInteraction.run`);
+        await dd.inc(`interactions.CommandInteraction.run`);
         const command = chatCommandsMap.get(interaction.commandName);
 
         if (!command) return;
@@ -154,7 +154,7 @@ export async function handleSelectInteraction(
     const playlistId = interaction.values[0].split("_")[1];
     // console.log(interaction.values[0])
     const songId = interaction.values[0].split("_")[2].split("&")[0]
-    const request = await JoshAPI.addPersonalPlaylist(userId, playlistId, songId, platforms[platform]);
+    const request = await JoshAPI.add(userId, playlistId, songId, platforms[platform]);
     if (request.status === true) {
       await interaction.editReply({
         embeds: [

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -141,11 +141,12 @@ export async function handleSelectInteraction(
   interaction: SelectMenuInteraction
 ): Promise<void> {
   await interaction.deferUpdate();
-  dd.inc(`interactions.SelectMenuInteraction.run`);
+  await dd.inc(`interactions.SelectMenuInteraction.run`);
   const userId = interaction.customId.split("select_")[1];
   const playlistId = interaction.values[0].split("_")[1];
   const songId = interaction.values[0].split("_")[2];
-  const request = await JoshAPI.addPersonalPlaylist(userId, playlistId, songId);
+  const platform = "apple-music"
+  const request = await JoshAPI.addPersonalPlaylist(userId, playlistId, songId, platform);
   if (request.status === true) {
     await interaction.editReply({
       embeds: [
@@ -166,12 +167,14 @@ export async function handleButtonInteraction(
   const platform = interaction.customId.split("_")[1];
   const action = interaction.customId.split("_")[2];
 
+  console.log(platforms[platform])
+
   if (action === "link") {
     const request = await JoshAPI.link(
       interaction.guild!.id,
       interaction.channel!.id,
       interaction.user!.id,
-        platforms[platform]
+        platform
     );
 
     await interaction.editReply({
@@ -181,6 +184,7 @@ export async function handleButtonInteraction(
         .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
         .join(" ")} account to tunes.ninja!](${request})`,
     });
+
   } else if (action === "unlink") {
     console.log(platforms[platform])
     const request = await JoshAPI.unlink(interaction.user!.id, platforms[platform]);

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -33,6 +33,7 @@ export async function handleInteraction(
 export async function handleContextInteraction(
   interaction: ContextMenuInteraction
 ): Promise<void> {
+  dd.inc(`interactions.ContextMenuInteraction.run`);
   let command;
 
   switch (interaction.targetType) {
@@ -56,7 +57,6 @@ export async function handleContextInteraction(
     }
 
     await command.run(interaction);
-    await dd.inc(`interactions.ContextMenuInteraction.run`);
   } catch (e) {
     switch (true) {
       case e instanceof DiscordAPIError:
@@ -91,6 +91,7 @@ export async function handleContextInteraction(
 export async function handleMessageInteraction(
   interaction: CommandInteraction
 ): Promise<void> {
+  dd.inc(`interactions.CommandInteraction.run`);
   const command = chatCommandsMap.get(interaction.commandName);
 
   if (!command) return;
@@ -105,7 +106,6 @@ export async function handleMessageInteraction(
     }
 
     await command.run(interaction);
-    await dd.inc(`interactions.CommandInteraction.run`);
   } catch (e) {
     switch (true) {
       case e instanceof DiscordAPIError:
@@ -141,6 +141,7 @@ export async function handleSelectInteraction(
   interaction: SelectMenuInteraction
 ): Promise<void> {
   await interaction.deferUpdate();
+  dd.inc(`interactions.SelectMenuInteraction.run`);
   const userId = interaction.customId.split("select_")[1];
   const playlistId = interaction.values[0].split("_")[1];
   const songId = interaction.values[0].split("_")[2];
@@ -155,13 +156,13 @@ export async function handleSelectInteraction(
       components: [],
     });
   }
-  await dd.inc(`interactions.SelectMenuInteraction.run`);
 }
 
 export async function handleButtonInteraction(
   interaction: ButtonInteraction
 ): Promise<void> {
   await interaction.deferUpdate();
+  dd.inc(`interactions.ButtonInteraction.run`);
   const platform = interaction.customId.split("button_")[1];
   const request = await JoshAPI.link(
     interaction.guild!.id,
@@ -171,5 +172,4 @@ export async function handleButtonInteraction(
   );
 
   console.log(request);
-  await dd.inc(`interactions.ButtonInteraction.run`);
 }

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -167,8 +167,6 @@ export async function handleButtonInteraction(
   const platform = interaction.customId.split("_")[1];
   const action = interaction.customId.split("_")[2];
 
-  console.log(platforms[platform])
-
   if (action === "link") {
     const request = await JoshAPI.link(
       interaction.guild!.id,
@@ -203,5 +201,6 @@ export async function handleButtonInteraction(
 
 export const platforms: Record<string, string> = {
   "apple-music": "appleMusic",
-  "spotify": "spotify"
+  "spotify": "spotify",
+  "appleMusic": "apple-music",
 }

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -145,6 +145,7 @@ export async function handleMessageInteraction(
 export async function handleSelectInteraction(
   interaction: SelectMenuInteraction
 ): Promise<void> {
+  if (interaction.customId.includes("unsync")) return;
   try {
     await interaction.deferUpdate();
     await dd.inc(`interactions.SelectMenuInteraction.run`);

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -163,19 +163,41 @@ export async function handleButtonInteraction(
 ): Promise<void> {
   await interaction.deferUpdate();
   dd.inc(`interactions.ButtonInteraction.run`);
-  const platform = interaction.customId.split("button_")[1];
-  const request = await JoshAPI.link(
-    interaction.guild!.id,
-    interaction.channel!.id,
-    interaction.user!.id,
-    platform
-  );
+  const platform = interaction.customId.split("_")[1];
+  const action = interaction.customId.split("_")[2];
 
-  await interaction.editReply({
-    components: [],
-    content: `[Click here to link your ${platform
-      .split("-")
-      .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
-      .join(" ")} account to tunes.ninja!](${request})`,
-  });
+  if (action === "link") {
+    const request = await JoshAPI.link(
+      interaction.guild!.id,
+      interaction.channel!.id,
+      interaction.user!.id,
+        platforms[platform]
+    );
+
+    await interaction.editReply({
+      components: [],
+      content: `[Click here to link your ${platform
+        .split("-")
+        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+        .join(" ")} account to tunes.ninja!](${request})`,
+    });
+  } else if (action === "unlink") {
+    console.log(platforms[platform])
+    const request = await JoshAPI.unlink(interaction.user!.id, platforms[platform]);
+    console.log(request)
+    await interaction.editReply({
+      components: [],
+      content: request
+        ? `Unlinked your ${platform
+            .split("-")
+            .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+            .join(" ")} account!`
+        : "Couldn't unlink.",
+    });
+  }
+}
+
+export const platforms: Record<string, string> = {
+  "apple-music": "appleMusic",
+  "spotify": "spotify"
 }

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -15,8 +15,9 @@ import {
 import { StandardEmbed } from "../../structs/standard-embed";
 import { DataDog } from "../api/datadog";
 import { JoshAPI } from "../api/josh";
+import * as Sentry from '@sentry/node';
 
-const dd = new DataDog();
+const dd = new DataDog()
 
 export async function handleInteraction(
   interaction: Interaction
@@ -58,6 +59,7 @@ export async function handleContextInteraction(
 
     await command.run(interaction);
   } catch (e) {
+    Sentry.captureException(e)
     switch (true) {
       case e instanceof DiscordAPIError:
         break;
@@ -91,114 +93,125 @@ export async function handleContextInteraction(
 export async function handleMessageInteraction(
   interaction: CommandInteraction
 ): Promise<void> {
-  dd.inc(`interactions.CommandInteraction.run`);
-  const command = chatCommandsMap.get(interaction.commandName);
+    try {
+        dd.inc(`interactions.CommandInteraction.run`);
+        const command = chatCommandsMap.get(interaction.commandName);
 
-  if (!command) return;
+        if (!command) return;
 
-  const inhibitors = Array.isArray(command.inhibitors)
-    ? command.inhibitors
-    : [command.inhibitors];
+        const inhibitors = Array.isArray(command.inhibitors)
+            ? command.inhibitors
+            : [command.inhibitors];
 
-  try {
-    for (const inhibitor of inhibitors) {
-      await inhibitor(interaction);
-    }
-
-    await command.run(interaction);
-  } catch (e) {
-    switch (true) {
-      case e instanceof DiscordAPIError:
-        break;
-      default:
         try {
-          if (!interaction.deferred) {
-            await interaction.reply({
-              ephemeral: true,
-              embeds: [
-                new StandardEmbed(
-                  interaction.member as GuildMember
-                ).setDescription(`⚠ ${e.message}`),
-              ],
-            });
-          } else {
-            await interaction.editReply({
-              embeds: [
-                new StandardEmbed(
-                  interaction.member as GuildMember
-                ).setDescription(`⚠ ${e.message}`),
-              ],
-            });
-          }
-        } catch (error) {
-          console.log("just give up");
+            for (const inhibitor of inhibitors) {
+                await inhibitor(interaction);
+            }
+            await command.run(interaction);
+        } catch (e) {
+            switch (true) {
+                case e instanceof DiscordAPIError:
+                    break;
+                default:
+                    try {
+                        if (!interaction.deferred) {
+                            await interaction.reply({
+                                ephemeral: true,
+                                embeds: [
+                                    new StandardEmbed(
+                                        interaction.member as GuildMember
+                                    ).setDescription(`⚠ ${e.message}`),
+                                ],
+                            });
+                        } else {
+                            await interaction.editReply({
+                                embeds: [
+                                    new StandardEmbed(
+                                        interaction.member as GuildMember
+                                    ).setDescription(`⚠ ${e.message}`),
+                                ],
+                            });
+                        }
+                    } catch (error) {
+                        console.log("just give up");
+                    }
+            }
         }
+    } catch (e) {
+        Sentry.captureException(e)
     }
-  }
+
 }
 
 export async function handleSelectInteraction(
   interaction: SelectMenuInteraction
 ): Promise<void> {
-  await interaction.deferUpdate();
-  await dd.inc(`interactions.SelectMenuInteraction.run`);
-  const userId = interaction.customId.split("select_")[1].split("_")[0];
-  const platform = interaction.customId.split("select_")[1].split("_")[1];
-  const playlistId = interaction.values[0].split("_")[1];
-  // console.log(interaction.values[0])
-  const songId = interaction.values[0].split("_")[2].split("&")[0]
-  console.log(userId, playlistId, songId, platform)
-  const request = await JoshAPI.addPersonalPlaylist(userId, playlistId, songId, platforms[platform]);
-  if (request.status === true) {
-    await interaction.editReply({
-      embeds: [
-        new StandardEmbed(interaction.member as GuildMember).setDescription(
-          `<:check:875543430464430081> Added the song to your playlist!`
-        ),
-      ],
-      components: [],
-    });
+  try {
+    await interaction.deferUpdate();
+    await dd.inc(`interactions.SelectMenuInteraction.run`);
+    const userId = interaction.customId.split("select_")[1].split("_")[0];
+    const platform = interaction.customId.split("select_")[1].split("_")[1];
+    const playlistId = interaction.values[0].split("_")[1];
+    // console.log(interaction.values[0])
+    const songId = interaction.values[0].split("_")[2].split("&")[0]
+    const request = await JoshAPI.addPersonalPlaylist(userId, playlistId, songId, platforms[platform]);
+    if (request.status === true) {
+      await interaction.editReply({
+        embeds: [
+          new StandardEmbed(interaction.member as GuildMember).setDescription(
+              `<:check:875543430464430081> Added the song to your playlist!`
+          ),
+        ],
+        components: [],
+      });
+    }
+  } catch (e) {
+    Sentry.captureException(e)
   }
 }
 
 export async function handleButtonInteraction(
   interaction: ButtonInteraction
 ): Promise<void> {
-  await interaction.deferUpdate();
-  dd.inc(`interactions.ButtonInteraction.run`);
-  const platform = interaction.customId.split("_")[1];
-  const action = interaction.customId.split("_")[2];
+    try {
+        await interaction.deferUpdate();
+        dd.inc(`interactions.ButtonInteraction.run`);
+        const platform = interaction.customId.split("_")[1];
+        const action = interaction.customId.split("_")[2];
 
-  if (action === "link") {
-    const request = await JoshAPI.link(
-      interaction.guild!.id,
-      interaction.channel!.id,
-      interaction.user!.id,
-        platform
-    );
+        if (action === "link") {
+            const request = await JoshAPI.link(
+                interaction.guild!.id,
+                interaction.channel!.id,
+                interaction.user!.id,
+                platform
+            );
 
-    await interaction.editReply({
-      components: [],
-      content: `[Click here to link your ${platform
-        .split("-")
-        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
-        .join(" ")} account to tunes.ninja!](${request})`,
-    });
+            await interaction.editReply({
+                components: [],
+                content: `[Click here to link your ${platform
+                    .split("-")
+                    .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+                    .join(" ")} account to tunes.ninja!](${request})`,
+            });
+        } else if (action === "unlink") {
+            console.log(platforms[platform])
+            const request = await JoshAPI.unlink(interaction.user!.id, platforms[platform]);
+            console.log(request)
+            await interaction.editReply({
+                components: [],
+                content: request
+                    ? `Unlinked your ${platform
+                        .split("-")
+                        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+                        .join(" ")} account!`
+                    : "Couldn't unlink.",
+            });
+        }
+    } catch (e) {
+        Sentry.captureException(e)
+    }
 
-  } else if (action === "unlink") {
-    console.log(platforms[platform])
-    const request = await JoshAPI.unlink(interaction.user!.id, platforms[platform]);
-    console.log(request)
-    await interaction.editReply({
-      components: [],
-      content: request
-        ? `Unlinked your ${platform
-            .split("-")
-            .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
-            .join(" ")} account!`
-        : "Couldn't unlink.",
-    });
-  }
 }
 
 export const platforms: Record<string, string> = {

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -15,9 +15,9 @@ import {
 import { StandardEmbed } from "../../structs/standard-embed";
 import { DataDog } from "../api/datadog";
 import { JoshAPI } from "../api/josh";
-import * as Sentry from '@sentry/node';
+import * as Sentry from "@sentry/node";
 
-const dd = new DataDog()
+const dd = new DataDog();
 
 export async function handleInteraction(
   interaction: Interaction
@@ -59,7 +59,7 @@ export async function handleContextInteraction(
 
     await command.run(interaction);
   } catch (e) {
-    Sentry.captureException(e)
+    Sentry.captureException(e);
     switch (true) {
       case e instanceof DiscordAPIError:
         break;
@@ -93,54 +93,53 @@ export async function handleContextInteraction(
 export async function handleMessageInteraction(
   interaction: CommandInteraction
 ): Promise<void> {
+  try {
+    await dd.inc(`interactions.CommandInteraction.run`);
+    const command = chatCommandsMap.get(interaction.commandName);
+
+    if (!command) return;
+
+    const inhibitors = Array.isArray(command.inhibitors)
+      ? command.inhibitors
+      : [command.inhibitors];
+
     try {
-        await dd.inc(`interactions.CommandInteraction.run`);
-        const command = chatCommandsMap.get(interaction.commandName);
-
-        if (!command) return;
-
-        const inhibitors = Array.isArray(command.inhibitors)
-            ? command.inhibitors
-            : [command.inhibitors];
-
-        try {
-            for (const inhibitor of inhibitors) {
-                await inhibitor(interaction);
-            }
-            await command.run(interaction);
-        } catch (e) {
-            switch (true) {
-                case e instanceof DiscordAPIError:
-                    break;
-                default:
-                    try {
-                        if (!interaction.deferred) {
-                            await interaction.reply({
-                                ephemeral: true,
-                                embeds: [
-                                    new StandardEmbed(
-                                        interaction.member as GuildMember
-                                    ).setDescription(`⚠ ${e.message}`),
-                                ],
-                            });
-                        } else {
-                            await interaction.editReply({
-                                embeds: [
-                                    new StandardEmbed(
-                                        interaction.member as GuildMember
-                                    ).setDescription(`⚠ ${e.message}`),
-                                ],
-                            });
-                        }
-                    } catch (error) {
-                        console.log("just give up");
-                    }
-            }
-        }
+      for (const inhibitor of inhibitors) {
+        await inhibitor(interaction);
+      }
+      await command.run(interaction);
     } catch (e) {
-        Sentry.captureException(e)
+      switch (true) {
+        case e instanceof DiscordAPIError:
+          break;
+        default:
+          try {
+            if (!interaction.deferred) {
+              await interaction.reply({
+                ephemeral: true,
+                embeds: [
+                  new StandardEmbed(
+                    interaction.member as GuildMember
+                  ).setDescription(`⚠ ${e.message}`),
+                ],
+              });
+            } else {
+              await interaction.editReply({
+                embeds: [
+                  new StandardEmbed(
+                    interaction.member as GuildMember
+                  ).setDescription(`⚠ ${e.message}`),
+                ],
+              });
+            }
+          } catch (error) {
+            console.log("just give up");
+          }
+      }
     }
-
+  } catch (e) {
+    Sentry.captureException(e);
+  }
 }
 
 export async function handleSelectInteraction(
@@ -153,69 +152,76 @@ export async function handleSelectInteraction(
     const platform = interaction.customId.split("select_")[1].split("_")[1];
     const playlistId = interaction.values[0].split("_")[1];
     // console.log(interaction.values[0])
-    const songId = interaction.values[0].split("_")[2].split("&")[0]
-    const request = await JoshAPI.add(userId, playlistId, songId, platforms[platform]);
+    const songId = interaction.values[0].split("_")[2].split("&")[0];
+    const request = await JoshAPI.addSongToPlaylist(
+      userId,
+      playlistId,
+      songId,
+      platforms[platform]
+    );
     if (request.status === true) {
       await interaction.editReply({
         embeds: [
           new StandardEmbed(interaction.member as GuildMember).setDescription(
-              `<:check:875543430464430081> Added the song to your playlist!`
+            `<:check:875543430464430081> Added the song to your playlist!`
           ),
         ],
         components: [],
       });
     }
   } catch (e) {
-    Sentry.captureException(e)
+    Sentry.captureException(e);
   }
 }
 
 export async function handleButtonInteraction(
   interaction: ButtonInteraction
 ): Promise<void> {
-    try {
-        await interaction.deferUpdate();
-        dd.inc(`interactions.ButtonInteraction.run`);
-        const platform = interaction.customId.split("_")[1];
-        const action = interaction.customId.split("_")[2];
+  try {
+    await interaction.deferUpdate();
+    dd.inc(`interactions.ButtonInteraction.run`);
+    const platform = interaction.customId.split("_")[1];
+    const action = interaction.customId.split("_")[2];
 
-        if (action === "link") {
-            const request = await JoshAPI.link(
-                interaction.guild!.id,
-                interaction.channel!.id,
-                interaction.user!.id,
-                platform
-            );
+    if (action === "link") {
+      const request = await JoshAPI.linkUser(
+        interaction.guild!.id,
+        interaction.channel!.id,
+        interaction.user!.id,
+        platform
+      );
 
-            await interaction.editReply({
-                components: [],
-                content: `[Click here to link your ${platform
-                    .split("-")
-                    .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
-                    .join(" ")} account to tunes.ninja!](${request})`,
-            });
-        } else if (action === "unlink") {
-            console.log(platforms[platform])
-            const request = await JoshAPI.unlink(interaction.user!.id, platforms[platform]);
-            console.log(request)
-            await interaction.editReply({
-                components: [],
-                content: request
-                    ? `Unlinked your ${platform
-                        .split("-")
-                        .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
-                        .join(" ")} account!`
-                    : "Couldn't unlink.",
-            });
-        }
-    } catch (e) {
-        Sentry.captureException(e)
+      await interaction.editReply({
+        components: [],
+        content: `[Click here to link your ${platform
+          .split("-")
+          .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+          .join(" ")} account to tunes.ninja!](${request})`,
+      });
+    } else if (action === "unlink") {
+      console.log(platforms[platform]);
+      const request = await JoshAPI.unlinkUser(
+        interaction.user!.id,
+        platforms[platform]
+      );
+      console.log(request);
+      await interaction.editReply({
+        components: [],
+        content: request
+          ? `Unlinked your ${platform
+              .split("-")
+              .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+              .join(" ")} account!`
+          : "Couldn't unlink.",
+      });
     }
-
+  } catch (e) {
+    Sentry.captureException(e);
+  }
 }
 
 export const platforms: Record<string, string> = {
   "apple-music": "appleMusic",
-  "spotify": "spotify",
-  "appleMusic": "apple-music",
-}
+  spotify: "spotify",
+  appleMusic: "apple-music",
+};

--- a/src/services/events/interaction.ts
+++ b/src/services/events/interaction.ts
@@ -172,4 +172,12 @@ export async function handleButtonInteraction(
   );
 
   console.log(request);
+
+  await interaction.editReply({
+    components: [],
+    content: `[Click here to link your ${platform
+      .split("-")
+      .map((w) => w[0].toUpperCase() + w.substr(1).toLowerCase())
+      .join(" ")} account to tunes.ninja!](${request})`,
+  });
 }

--- a/src/services/reply-song.ts
+++ b/src/services/reply-song.ts
@@ -84,8 +84,6 @@ export async function returnLinks(
     },
   });
 
-  console.log(channels);
-
   if (channels) {
     channels.map(async (channel) => {
       let songID: string;
@@ -96,7 +94,6 @@ export async function returnLinks(
           )[1];
           break;
         case "apple-music":
-          console.log("bruh");
           songID = song.links!.apple_music!.split("i=")[1].split("&")[0];
           break;
         default:

--- a/src/services/reply-song.ts
+++ b/src/services/reply-song.ts
@@ -82,9 +82,10 @@ export async function returnLinks(
     },
   });
 
-  if (channel) {
-    await JoshAPI.add(message, link);
-  }
+  // if (channel) {
+  //   await JoshAPI.add(message, link);
+  // }
+
   await incrementSearches(author as User);
   await dd.inc("interactions.song");
 }

--- a/src/services/reply-song.ts
+++ b/src/services/reply-song.ts
@@ -90,8 +90,9 @@ export async function returnLinks(
           "https://open.spotify.com/track/"
         )[1];
         break;
-      case "appleMusic":
-        songID = song.links!.apple_music!.split("?i=")[1];
+      case "apple-music":
+        console.log("bruh");
+        songID = song.links!.apple_music!.split("i=")[1].split("&")[0];
         break;
       default:
         throw new Error(
@@ -99,11 +100,11 @@ export async function returnLinks(
         );
     }
 
-    await JoshAPI.addToPlaylist(
-      message,
-      channel.platform,
+    await JoshAPI.addSongToPlaylist(
+      (author as User).id,
       channel.playlistID,
-      songID
+      songID,
+      channel.platform
     );
   }
 

--- a/src/services/reply-song.ts
+++ b/src/services/reply-song.ts
@@ -12,7 +12,7 @@ import { JoshAPI } from "./api/josh";
 import { SongsApi } from "./api/song";
 import { incrementSearches, prisma } from "./prisma";
 
-const dd = new DataDog()
+const dd = new DataDog();
 
 export async function returnLinks(
   message: Message | CommandInteraction | ContextMenuInteraction,
@@ -82,9 +82,30 @@ export async function returnLinks(
     },
   });
 
-  // if (channel) {
-  //   await JoshAPI.add(message, link);
-  // }
+  if (channel) {
+    let songID: string;
+    switch (channel.platform) {
+      case "spotify":
+        songID = song.links!.spotify!.split(
+          "https://open.spotify.com/track/"
+        )[1];
+        break;
+      case "appleMusic":
+        songID = song.links!.apple_music!.split("?i=")[1];
+        break;
+      default:
+        throw new Error(
+          "this shouldn't happen lol, do `/support` for help and please report this :)"
+        );
+    }
+
+    await JoshAPI.addToPlaylist(
+      message,
+      channel.platform,
+      channel.playlistID,
+      songID
+    );
+  }
 
   await incrementSearches(author as User);
   await dd.inc("interactions.song");
@@ -101,6 +122,7 @@ function chunk<T>(array: T[], size: number): T[][] {
 
 export const PLATFORM_EMOJI: Record<string, string> = {
   apple_music: "<:apple_music:847868738870968380>",
+  "apple-music": "<:apple_music:847868738870968380>",
   appleMusic: "<:apple_music:847868738870968380>",
   soundcloud: "<:soundcloud:847868739257106453>",
   spotify: "<:spotify:847868739298131998>",

--- a/src/services/reply-song.ts
+++ b/src/services/reply-song.ts
@@ -114,6 +114,10 @@ export async function returnLinks(
         songID,
         channel.platform
       );
+
+      if (message instanceof Message) {
+        await message.react("🔁")
+      }
     });
   }
 

--- a/src/services/reply-song.ts
+++ b/src/services/reply-song.ts
@@ -100,6 +100,7 @@ function chunk<T>(array: T[], size: number): T[][] {
 
 export const PLATFORM_EMOJI: Record<string, string> = {
   apple_music: "<:apple_music:847868738870968380>",
+  appleMusic: "<:apple_music:847868738870968380>",
   soundcloud: "<:soundcloud:847868739257106453>",
   spotify: "<:spotify:847868739298131998>",
   tidal: "<:tidal:847868738254012467>",

--- a/src/services/reply-song.ts
+++ b/src/services/reply-song.ts
@@ -72,6 +72,12 @@ export async function returnLinks(
     );
   }
 
+  if (Math.floor(Math.random() * 10) == 2) {
+    embed.setDescription(
+      "*:ninja: Psst - tunes.ninja can link with your Spotify and Apple Music! Just do `/api link` to get started*"
+    );
+  }
+
   if (message instanceof Message) {
     await message.reply({ embeds: [embed], components: rows });
   } else {

--- a/src/services/reply-song.ts
+++ b/src/services/reply-song.ts
@@ -12,7 +12,7 @@ import { JoshAPI } from "./api/josh";
 import { SongsApi } from "./api/song";
 import { incrementSearches, prisma } from "./prisma";
 
-const dd = new DataDog();
+const dd = new DataDog()
 
 export async function returnLinks(
   message: Message | CommandInteraction | ContextMenuInteraction,

--- a/src/services/util/count.ts
+++ b/src/services/util/count.ts
@@ -1,5 +1,7 @@
 import {prisma} from "../prisma";
 import {wrapRedis} from "../redis";
+import {Client} from "discord.js";
+import {Topgg} from "../api/topgg";
 
 const TEN_MINUTES_IN_SECONDS = 600;
 
@@ -24,3 +26,37 @@ export function countProfiles(): Promise<number> {
     TEN_MINUTES_IN_SECONDS
   );
 }
+
+export function countPlaylists(): Promise<number> {
+    return wrapRedis(
+        "playlists:count",
+        async () => {
+            const stats = await prisma.joshChannel.findMany({});
+            return stats.length || 0;
+        },
+        TEN_MINUTES_IN_SECONDS
+    );
+}
+
+export function countGuilds(client: Client): Promise<number> {
+    return wrapRedis(
+        "bot:guilds",
+        async () => {
+            const stats = await client.guilds.cache.size;
+            return stats || 0;
+        },
+        TEN_MINUTES_IN_SECONDS
+    );
+}
+
+export function countVotes(client: Client): Promise<number> {
+    return wrapRedis(
+        "bot:votes",
+        async () => {
+            const votes = await new Topgg(client.user!.id).getVotes();
+            return votes.monthlyPoints || 0;
+        },
+        TEN_MINUTES_IN_SECONDS
+    );
+}
+

--- a/src/services/util/server.ts
+++ b/src/services/util/server.ts
@@ -3,6 +3,7 @@ import * as TopGG from "@top-gg/sdk";
 import { redis } from "../redis";
 import * as logs from "../events/logging";
 import { AbstractAppService } from "./abstract-app-service";
+import {countGuilds, countPlaylists, countProfiles, countSearches, countVotes} from "./count";
 
 const SIX_HOURS_IN_SECONDS = 60 * 60 * 6;
 
@@ -29,6 +30,19 @@ export class VotesServer extends AbstractAppService {
       })
     );
 
+      this.app.get("/stats", async (req, res) => {
+          const songs = await countSearches();
+          const profiles = await countProfiles();
+          const playlists = await countPlaylists();
+          const guilds = await countGuilds(this.client);
+          const votes = await countVotes(this.client);
+
+          await res.send({
+              songs, profiles, playlists, guilds, votes
+          })
+      })
+
     this.app.listen(process.env.SERVER_PORT || 8097);
   }
+
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,7 +784,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dogapi@2.8.4, dogapi@^2.8.4:
+dogapi@2.8.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/dogapi/-/dogapi-2.8.4.tgz#ada64f20c6acdea206b9fd9e70df0c96241b6621"
   integrity sha512-065fsvu5dB0o4+ENtLjZILvXMClDNH/yA9H6L8nsdcNiz9l0Hzpn7aQaCOPYXxqyzq4CRPOdwkFXUjDOXfRGbg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,6 +757,11 @@ datadog-metrics@^0.9.3:
     debug "3.1.0"
     dogapi "2.8.4"
 
+dayjs@^1.10.7:
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
+  integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,6 +130,84 @@
   resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.1.4.tgz#ae431310917a8880961cebe8e59df6ffa40f2957"
   integrity sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA==
 
+"@sentry/browser@^6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.11.0.tgz#9e90bbc0488ebcdd1e67937d8d5b4f13c3f6dee0"
+  integrity sha512-Qr2QRA0t5/S9QQqxzYKvM9W8prvmiWuldfwRX4hubovXzcXLgUi4WK0/H612wSbYZ4dNAEcQbtlxFWJNN4wxdg==
+  dependencies:
+    "@sentry/core" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/core@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.11.0.tgz#40e94043afcf6407a109be26655c77832c64e740"
+  integrity sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.11.0.tgz#ddf9ddb0577d1c8290dc02c0242d274fe84d6c16"
+  integrity sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==
+  dependencies:
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.11.0.tgz#806d5512658370e40827b3e3663061db708fff33"
+  integrity sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/types" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/node@^6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.11.0.tgz#62614c18af779373a12311f2fb57a8dde278425a"
+  integrity sha512-vbk+V/n7ZIFD8rHPYy03t/gIG5V7LGdjU4qJxVDgNZzticfWPnd2sLgle/r+l60XF6SKW/epG4rnxnBcgPdWaw==
+  dependencies:
+    "@sentry/core" "6.11.0"
+    "@sentry/hub" "6.11.0"
+    "@sentry/tracing" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/tracing@6.11.0", "@sentry/tracing@^6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.11.0.tgz#9bd9287addea1ebc12c75b226f71c7713c0fac4f"
+  integrity sha512-9VA1/SY++WeoMQI4K6n/sYgIdRtCu9NLWqmGqu/5kbOtESYFgAt1DqSyqGCr00ZjQiC2s7tkDkTNZb38K6KytQ==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/types@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
+  integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
+
+"@sentry/utils@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.11.0.tgz#d1dee4faf4d9c42c54bba88d5a66fb96b902a14c"
+  integrity sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==
+  dependencies:
+    "@sentry/types" "6.11.0"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
@@ -371,6 +449,13 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -625,6 +710,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
@@ -681,7 +771,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1, debug@^4.1.1, debug@^4.3.1:
+debug@4, debug@^4.0.1, debug@^4.1.1, debug@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -1262,6 +1352,14 @@ http-errors@1.7.3, http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -1513,6 +1611,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 luxon@^1.26.0:
   version "1.28.0"
@@ -2254,7 +2357,7 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.8.1:
+tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,10 +108,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@prisma/client@^2.19.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.29.0.tgz#e236577e2a2b6ed718ecc606bac05e3603bf054c"
-  integrity sha512-te4dNyWI2ypZ7XCBtv42YZvsHDuwXqikepBFUhXsaoB7WFSZEtKDQp+xsEuMyk5NG4PQWVQx73jkcONFSHorJg==
+"@prisma/client@^2.29.1":
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.29.1.tgz#a7b91c9644800de4e00b2f7c3789ff4bae42b3d6"
+  integrity sha512-GhieSvHGPIV5IwRYIkJ4FrGSNfX18lPhFtlyVWxhvX0ocdy8oTnjNZVTFgGxB6qVmJIUpH1HsckAzIoAX689IA==
   dependencies:
     "@prisma/engines-version" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
 
@@ -1898,10 +1898,10 @@ prism-media@^1.2.9:
   resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.3.1.tgz#418acd2b122bedea2e834056d678f9a5ad2943ae"
   integrity sha512-nyYAa3KB4qteJIqdguKmwxTJgy55xxUtkJ3uRnOvO5jO+frci+9zpRXw6QZVcfDeva3S654fU9+26P2OSTzjHw==
 
-prisma@^2.19.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.29.0.tgz#dbd801eab9b87cb1cb543f0baadac79cd658dd39"
-  integrity sha512-fOnPzF45X3eq4EFVC39MV7pJf1y6VNC8BMqHRJ5+vBvn2SDjxf0OskUM1DUDkZFIViqZykvDlB9HMPH3edOB/A==
+prisma@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.29.1.tgz#7845f55c7f09955b01f973c6a4b1f330cb212e7d"
+  integrity sha512-fRGh90+z0m3Jw3D6KBE6wyVCRR0w6M6QD93jh+em8IOQycmC48zB8hho8zeri3J9//C0k8fkDeQrRLJUosXROw==
   dependencies:
     "@prisma/engines" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
 


### PR DESCRIPTION
This PR includes the code for tunes.ninja version 2.0.0 - here are (most) of the changes.

- Added Apple Music integration to tunes.ninja. This allows users to sync their Apple Music accounts
- Added global "Add to Playlist" context menu integration that allows users to pick from their Spotify & Apple Music playlists
- Added "Add to Spotify Queue" context menu integration
- Added multiple synced playlists per channel
- Added random hint to integrate with tunes.ninja's API
- Added Sentry error logging
- Added DataDog statistics tracking
- Added server endpoint to retrieve bot statistics
- Rewrote API link/unlink logic
- Rewrote button interaction handling
- Reformatted stats command
- Large bug fixes and improvements

This PR wouldn't be possible without the fantastic work of @ms7m on the backend <3